### PR TITLE
[Item][Events] Send original event object to handler function arguments for mouse events

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,19 @@ Callback when an item is moved. Returns 1) the item's ID, 2) the new start time 
 ### onItemResize(itemId, newResizeEnd)
 Callback when an item is resized. Returns 1) the item's ID, 2) the new end time of the item
 
-### onItemSelect(itemId)
+### onItemSelect(itemId, e)
 Called when an item is selected. This is sent on the first click on an item.
 
-### onItemClick(itemId)
+### onItemClick(itemId, e)
 Called when an item is clicked. Note: the item must be selected before it's clicked... except if it's a touch event and `itemTouchSendsClick` is enabled.
 
 ### onCanvasClick(groupId, time, e)
 Called when an empty spot on the canvas was clicked. Get the group ID and the time as arguments. For example open a "new item" window after this.
 
-### onItemDoubleClick(itemId)
+### onItemDoubleClick(itemId, e)
 Called when an item was double clicked
 
-### onItemContextMenu(itemId)
+### onItemContextMenu(itemId, e)
 Called when the item is clicked by the right button of the mouse. Note: If this property is set the default context menu doesn't appear
 
 ### moveResizeValidator(action, itemId, time)

--- a/src/lib/Timeline.jsx
+++ b/src/lib/Timeline.jsx
@@ -383,15 +383,15 @@ export default class ReactCalendarTimeline extends Component {
     this.props.onTimeChange.bind(this)(visibleTimeStart, visibleTimeStart + zoom)
   }
 
-  selectItem (item, clickType) {
+  selectItem (item, clickType, e) {
     if (this.state.selectedItem === item || (this.props.itemTouchSendsClick && clickType === 'touch')) {
       if (item && this.props.onItemClick) {
-        this.props.onItemClick(item)
+        this.props.onItemClick(item, e)
       }
     } else {
       this.setState({selectedItem: item})
       if (item && this.props.onItemSelect) {
-        this.props.onItemSelect(item)
+        this.props.onItemSelect(item, e)
       }
     }
   }

--- a/src/lib/items/Item.jsx
+++ b/src/lib/items/Item.jsx
@@ -308,7 +308,7 @@ export default class Item extends Component {
     e.preventDefault()
     e.stopPropagation()
     if (this.props.onItemDoubleClick) {
-      this.props.onItemDoubleClick(this.itemId)
+      this.props.onItemDoubleClick(this.itemId, e)
     }
   };
 
@@ -316,13 +316,13 @@ export default class Item extends Component {
     if (this.props.onContextMenu) {
       e.preventDefault()
       e.stopPropagation()
-      this.props.onContextMenu(this.itemId)
+      this.props.onContextMenu(this.itemId, e)
     }
   };
 
   actualClick (e, clickType) {
     if (this.props.onSelect) {
-      this.props.onSelect(this.itemId, clickType)
+      this.props.onSelect(this.itemId, clickType, e)
     }
   }
 


### PR DESCRIPTION
Sometimes it can be useful to have original event object inside handler method arguments. 
For example to get coordinates of the mouse cursor on rightClick / doubleClick and open custom context menu at the appropriate place.

In this PR I added this just for simple mouse events. Probably in future, it will make sense to do the same for interact.js events (for such handlers like onItemMove, onItemResize).