### PR TITLE
Fixed memory leak when attach\deattach touch[start,move,end] listeners

### DIFF
--- a/src/lib/Timeline.jsx
+++ b/src/lib/Timeline.jsx
@@ -96,19 +96,20 @@ export default class ReactCalendarTimeline extends Component {
     window.addEventListener('resize', this.resizeEventListener)
 
     this.lastTouchDistance = null
-    this.refs.scrollComponent.addEventListener('touchstart', this.touchStart.bind(this))
-    this.refs.scrollComponent.addEventListener('touchmove', this.touchMove.bind(this))
-    this.refs.scrollComponent.addEventListener('touchend', this.touchEnd.bind(this))
+
+    this.refs.scrollComponent.addEventListener('touchstart', this.touchStart)
+    this.refs.scrollComponent.addEventListener('touchmove', this.touchMove)
+    this.refs.scrollComponent.addEventListener('touchend', this.touchEnd)
   }
 
   componentWillUnmount () {
     window.removeEventListener('resize', this.resizeEventListener)
-    this.refs.scrollComponent.removeEventListener('touchstart', this.touchStart.bind(this))
-    this.refs.scrollComponent.removeEventListener('touchmove', this.touchMove.bind(this))
-    this.refs.scrollComponent.removeEventListener('touchend', this.touchEnd.bind(this))
+    this.refs.scrollComponent.removeEventListener('touchstart', this.touchStart)
+    this.refs.scrollComponent.removeEventListener('touchmove', this.touchMove)
+    this.refs.scrollComponent.removeEventListener('touchend', this.touchEnd)
   }
 
-  touchStart (e) {
+  touchStart = (e) => {
     if (e.touches.length === 2) {
       e.preventDefault()
 
@@ -127,7 +128,7 @@ export default class ReactCalendarTimeline extends Component {
     }
   }
 
-  touchMove (e) {
+  touchMove = (e) => {
     if (this.state.dragTime || this.state.resizeEnd) {
       e.preventDefault()
       return
@@ -170,7 +171,7 @@ export default class ReactCalendarTimeline extends Component {
     }
   }
 
-  touchEnd (e) {
+  touchEnd = (e) => {
     if (this.lastTouchDistance) {
       e.preventDefault()
 


### PR DESCRIPTION
Hi, as far as i know, .bind(this) !== .bind(this), so your handlers will never be de-attached. That cause memory leak in my application.

This PR eliminate this issue.

BR