### PR TITLE
ADD: Option for multiple selected Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Expects either a vanilla JS array or an immutableJS array, consisting of objects
 
 The preferred (fastest) option is to give unix timestamps in milliseconds for `start_time` and `end_time`. Objects that convert to them (java Date or moment()) will also work, but will be a lot slower.
 
+### selected
+An array with id's corresponding to id's in items (`item.id`). If this prop is set you have to manage the selected items yourself within the `onItemSelect` handler to update the property with new id's. This overwrites the default behaviour of selecting one item on click. 
+
 ### keys
 An array specifying keys in the `items` and `groups` objects. Defaults to
 ```

--- a/index.html
+++ b/index.html
@@ -90,6 +90,8 @@
         itemTimeEndKey: 'end'
       },
 
+      selected: null,
+
       onCanvasClick: function(event) {
         console.log("Canvas clicked");
       },

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -91,7 +91,9 @@ export default class ReactCalendarTimeline extends Component {
     onTimeInit: PropTypes.func,
     onBoundsChange: PropTypes.func,
 
-    children: PropTypes.node
+    children: PropTypes.node,
+
+    selected: PropTypes.array
   }
 
   static defaultProps = {
@@ -153,7 +155,9 @@ export default class ReactCalendarTimeline extends Component {
     onTimeInit: null,
     // called when the canvas area of the calendar changes
     onBoundsChange: null,
-    children: null
+    children: null,
+
+    selected: null
   }
 
   constructor (props) {
@@ -689,7 +693,8 @@ export default class ReactCalendarTimeline extends Component {
              onItemDoubleClick={this.props.onItemDoubleClick}
              onItemContextMenu={this.props.onItemContextMenu}
              itemResizing={this.resizingItem}
-             itemResized={this.resizedItem} />
+             itemResized={this.resizedItem}
+             selected={this.props.selected} />
     )
   }
 

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -43,10 +43,13 @@ export default class Items extends Component {
     itemResized: PropTypes.func,
 
     onItemDoubleClick: PropTypes.func,
-    onItemContextMenu: PropTypes.func
+    onItemContextMenu: PropTypes.func,
+
+    selected: PropTypes.array
   }
 
   static defaultProps = {
+    selected: []
   }
 
   shouldComponentUpdate (nextProps, nextState) {
@@ -57,6 +60,7 @@ export default class Items extends Component {
              nextProps.canvasTimeEnd === this.props.canvasTimeEnd &&
              nextProps.canvasWidth === this.props.canvasWidth &&
              nextProps.selectedItem === this.props.selectedItem &&
+             nextProps.selected === this.props.selected &&
              nextProps.lineHeight === this.props.lineHeight &&
              nextProps.dragSnap === this.props.dragSnap &&
              nextProps.minResizeWidth === this.props.minResizeWidth &&
@@ -79,6 +83,15 @@ export default class Items extends Component {
     }
 
     return groupOrders
+  }
+
+  isSelected (item, itemIdKey) {
+    if (!this.props.selected) {
+      return this.props.selectedItem === _get(item, itemIdKey)
+    } else {
+      let target = _get(item, itemIdKey)
+      return this.props.selected.find((value) => value === target)
+    }
   }
 
   getVisibleItems (canvasTimeStart, canvasTimeEnd, groupOrders) {
@@ -105,7 +118,7 @@ export default class Items extends Component {
                                         keys={this.props.keys}
                                         order={groupOrders[_get(item, itemGroupKey)]}
                                         dimensions={sortedDimensionItems[_get(item, itemIdKey)].dimensions}
-                                        selected={this.props.selectedItem === _get(item, itemIdKey)}
+                                        selected={this.isSelected(item, itemIdKey)}
                                         canChangeGroup={_get(item, 'canChangeGroup') !== undefined ? _get(item, 'canChangeGroup') : this.props.canChangeGroup}
                                         canMove={_get(item, 'canMove') !== undefined ? _get(item, 'canMove') : this.props.canMove}
                                         canResizeLeft={canResizeLeft(item, this.props.canResize)}


### PR DESCRIPTION
If you pass the prop `selected=['id1','id2']` to the timeline component the default behaviour of selecting only one item at a time is overwritten. From then on you have to manage the selected items yourself within the `onItemSelect` handler and pass the new id's to the selected props again. This enables you to have multiple items selected. This change is not breaking the existing behaviour because if `selected` is not set nothing changes for the user.

