### PR TITLE
Avoid updating updateDimensions right after updateScrollCanvas

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -362,9 +362,7 @@ export default class ReactCalendarTimeline extends Component {
 
     if (visibleTimeStart && visibleTimeEnd) {
       this.updateScrollCanvas(visibleTimeStart, visibleTimeEnd, items !== this.props.items || groups !== this.props.groups, items, groups)
-    }
-
-    if (items !== this.props.items || groups !== this.props.groups) {
+    } else if (items !== this.props.items || groups !== this.props.groups) {
       this.updateDimensions(items, groups)
     }
   }


### PR DESCRIPTION
Because setState runs at the end of updateScrollCanvas and applies the update asynchronously, updateDimensions computes using stale state.  When visibleTimeStart and visibleTimeEnd are specified this causes the items to be drawn in the wrong place occasionally when scrolling.  This update fixes it.  Since updateScrollCanvas already updates the item dimensions the call to updateDimensions is redundant anyway.