### PR TITLE
Disable cursor style by interactjs

### DIFF
--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -194,6 +194,7 @@ export default class Item extends Component {
       .draggable({
         enabled: this.props.selected
       })
+      .styleCursor(false)
       .on('dragstart', (e) => {
         if (this.props.selected) {
           this.setState({


### PR DESCRIPTION
Hey, the interactjs cursor styling is unnecessary since timeline calendar will already take care of it. Also there is currently a bug with interactjs cursors where it gets stuck on html tag. https://github.com/taye/interact.js/issues/497