### PR TITLE
FIX: renders with empty groups-array

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -853,6 +853,18 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   stackItems (items, groups, canvasTimeStart, visibleTimeStart, visibleTimeEnd, width) {
+
+    // if there are no groups return an empty array of dimensions
+    if(groups.length === 0) {
+      return {
+        dimensionItems: [],
+        height: 0,
+        groupHeights: 0,
+        groupTops: 0,
+      };
+    }
+
+
     const { keys, dragSnap, lineHeight, headerLabelGroupHeight, headerLabelHeight, stackItems, fullUpdate, itemHeightRatio } = this.props
     const { draggingItem, dragTime, resizingItem, resizingEdge, resizeTime, newGroupOrder } = this.state
     const zoom = visibleTimeEnd - visibleTimeStart

--- a/src/lib/__tests__/index.js
+++ b/src/lib/__tests__/index.js
@@ -44,4 +44,20 @@ describe('Timeline', () => {
     expect(itemsOrder[1].title).toBe('item 1')
     expect(itemsOrder[2].title).toBe('item 3')
   })
+  it('renders component with empty groups', () => {
+
+    let allCorrect = true;
+    try {
+      const wrapper = mount(
+        <Timeline groups={[]}
+                  items={items}
+                  defaultTimeStart={moment('1995-12-25').add(-12, 'hour')}
+                  defaultTimeEnd={moment('1995-12-25').add(12, 'hour')}
+                  />,
+      );
+    } catch(err) {
+      allCorrect = false;
+    }
+    expect(allCorrect).toBe(true);
+  })
 })


### PR DESCRIPTION
If the Timeline had no grups;

```jsx
<Timeline
  groups={[]}
  items={items}
  defaultTimeStart={moment('1995-12-25').add(-12, 'hour')}
  defaultTimeEnd={moment('1995-12-25').add(12, 'hour')}
/>
```

the component threw a error. I handled this case in `stackItems` because this gets executed already in the constructor. Someone a better idea where to handle it?