### PR TITLE
FIX: if items with no corresponding group

### DIFF
--- a/src/lib/__tests__/index.js
+++ b/src/lib/__tests__/index.js
@@ -59,4 +59,30 @@ describe('Timeline', () => {
     }
     expect(allCorrect).toBe(true)
   })
+
+  it('renders items without corresponding group', () => {
+    let itemsNoValidGroup = [
+      {
+        start_time: moment('1995-12-25').add(-2, 'hour'),
+        end_time: moment('1995-12-25').add(2, 'hour'),
+        group: -1, // this ID is not found in groups!
+        id: 1,
+        title: 'Title'
+      }
+    ]
+
+    let allCorrect = true
+    try {
+      mount(
+        <Timeline groups={groups}
+                  items={itemsNoValidGroup}
+                  defaultTimeStart={moment('1995-12-25').add(-12, 'hour')}
+                  defaultTimeEnd={moment('1995-12-25').add(12, 'hour')}
+                  />,
+      )
+    } catch (err) {
+      allCorrect = false
+    }
+    expect(allCorrect).toBe(true)
+  })
 })

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -310,7 +310,9 @@ export function getGroupedItems (items, groupOrders) {
   }
   // Populate groups
   for (let i = 0; i < items.length; i++) {
-    arr[items[i].dimensions.order].push(items[i])
+    if (items[i].dimensions.order) {
+      arr[items[i].dimensions.order].push(items[i])
+    }
   }
 
   return arr


### PR DESCRIPTION
```js
let groups = [
  {
    id: 1,
    title: 'Title'
  }
]
let items = [
  {
    ...
    group: -1, // here is the problem!
    title: 'Title'
  }
]
```