### PR TITLE
check group order for undefined in getGroupedItems

### DIFF
--- a/src/lib/__tests__/index.js
+++ b/src/lib/__tests__/index.js
@@ -44,6 +44,21 @@ describe('Timeline', () => {
     expect(itemsOrder[1].title).toBe('item 1')
     expect(itemsOrder[2].title).toBe('item 3')
   })
+  it('assigns top dimension to all items', () => {
+    const wrapper = mount(
+      <Timeline groups={groups}
+                items={items}
+                defaultTimeStart={moment('1995-12-25').add(-12, 'hour')}
+                defaultTimeEnd={moment('1995-12-25').add(12, 'hour')}
+                />,
+    )
+
+    // get the items parent
+    const itemsRendered = wrapper.find('.rct-items')
+    itemsRendered.props().children.forEach((item) => {
+      expect(item.props.dimensions.top).not.toBeNull()
+    })
+  })
   it('renders component with empty groups', () => {
     let allCorrect = true
     try {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -310,7 +310,7 @@ export function getGroupedItems (items, groupOrders) {
   }
   // Populate groups
   for (let i = 0; i < items.length; i++) {
-    if (items[i].dimensions.order) {
+    if (items[i].dimensions.order !== undefined) {
       arr[items[i].dimensions.order].push(items[i])
     }
   }


### PR DESCRIPTION
The items from the first group don't get rendered properly, because they have an order of 0 and the getGroupedItems method only does a falsy comparison