### PR TITLE
Refactoring of calculateDimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ bower_components
 .idea
 .sass-cache
 modules
-lib
+/lib
 build
 gh-pages

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -971,31 +971,45 @@ export default class ReactCalendarTimeline extends Component {
     const visibleItems = getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys)
     const groupOrders = getGroupOrders(groups, keys)
 
-    let dimensionItems = visibleItems.map(item => {
-      return {
-        id: _get(item, keys.itemIdKey),
-        dimensions: calculateDimensions({
-          item,
-          order: groupOrders[_get(item, keys.itemGroupKey)],
-          keys,
-          canvasTimeStart,
-          canvasTimeEnd,
-          canvasWidth,
-          dragSnap,
-          lineHeight,
-          draggingItem,
-          dragTime,
-          resizingItem,
-          resizingEdge,
-          resizeTime,
-          newGroupOrder,
-          itemHeightRatio,
-          fullUpdate,
-          visibleTimeStart,
-          visibleTimeEnd
+    let dimensionItems = visibleItems.reduce((memo, item) => {
+      const itemId = _get(item, keys.itemIdKey)
+      const isDragging = (itemId === draggingItem)
+      const isResizing = (itemId === resizingItem)
+
+      let dimension = calculateDimensions({
+        itemTimeStart: _get(item, keys.itemTimeStartKey),
+        itemTimeEnd: _get(item, keys.itemTimeEndKey),
+        isDragging,
+        isResizing,
+        canvasTimeStart,
+        canvasTimeEnd,
+        canvasWidth,
+        dragSnap,
+        dragTime,
+        resizingItem,
+        resizingEdge,
+        resizeTime,
+        fullUpdate,
+        visibleTimeStart,
+        visibleTimeEnd
+      })
+
+      if (dimension) {
+        dimension.top = null
+        dimension.order = isDragging ? newGroupOrder : groupOrders[_get(item, keys.itemGroupKey)]
+        dimension.stack = !item.isOverlay
+        dimension.height = lineHeight * itemHeightRatio
+        dimension.lineHeight = lineHeight
+        dimension.isDragging = isDragging
+
+        memo.push({
+          id: itemId,
+          dimensions: dimension
         })
       }
-    }).filter(i => i.dimensions)
+
+      return memo
+    }, [])
 
     const stackingMethod = stackItems ? stack : nostack
 

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -846,7 +846,6 @@ export default class ReactCalendarTimeline extends Component {
       <Items canvasTimeStart={canvasTimeStart}
              canvasTimeEnd={canvasTimeEnd}
              canvasWidth={canvasWidth}
-             lineHeight={this.props.lineHeight}
              lineCount={_length(this.props.groups)}
              dimensionItems={dimensionItems}
              minUnit={minUnit}
@@ -999,7 +998,6 @@ export default class ReactCalendarTimeline extends Component {
         dimension.order = isDragging ? newGroupOrder : groupOrders[_get(item, keys.itemGroupKey)]
         dimension.stack = !item.isOverlay
         dimension.height = lineHeight * itemHeightRatio
-        dimension.lineHeight = lineHeight
         dimension.isDragging = isDragging
 
         memo.push({

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -1,0 +1,235 @@
+import { calculateDimensions } from '../utils.js'
+
+describe('calculateDimensions', () => {
+  it('the item is full on a canvas no draging no resizing', () => {
+    const dimension = calculateDimensions({
+      itemTimeStart: 200,
+      itemTimeEnd: 300,
+      isDragging: false,
+      isResizing: false,
+      canvasTimeStart: 0,
+      canvasTimeEnd: 500,
+      canvasWidth: 500,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      fullUpdate: true,
+      visibleTimeStart: 0,
+      visibleTimeEnd: 500
+    })
+
+    expect(dimension).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 200,
+      collisionWidth: 100,
+      left: 200,
+      originalLeft: 200,
+      width: 100
+    })
+  })
+
+  it('the item is moved and snapped to the grid', () => {
+    const dimension = calculateDimensions({
+      itemTimeStart: 200,
+      itemTimeEnd: 300,
+      isDragging: true,
+      isResizing: false,
+      canvasTimeStart: 0,
+      canvasTimeEnd: 500,
+      canvasWidth: 500,
+      dragSnap: 10,
+      dragTime: 192,
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      fullUpdate: true,
+      visibleTimeStart: 0,
+      visibleTimeEnd: 500
+    })
+
+    expect(dimension).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 192,
+      collisionWidth: 108,
+      left: 192,
+      originalLeft: 200,
+      width: 100
+    })
+  })
+
+  it('the item is on the left side clipped', () => {
+    let example = {
+      itemTimeStart: 0,
+      itemTimeEnd: 300,
+      isDragging: false,
+      isResizing: false,
+      canvasTimeStart: 100,
+      canvasTimeEnd: 500,
+      canvasWidth: 400,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      fullUpdate: true,
+      visibleTimeStart: 100,
+      visibleTimeEnd: 500
+    }
+    expect(calculateDimensions(example)).toMatchObject({
+      clippedLeft: true,
+      clippedRight: false,
+      collisionLeft: 0,
+      collisionWidth: 300,
+      left: 0,
+      originalLeft: 0,
+      width: 200
+    })
+    // if we don't do the fullUpdate we don't get correct
+    // clipping informations
+    example.fullUpdate = false
+    expect(calculateDimensions(example)).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 0,
+      collisionWidth: 300,
+      left: -100,
+      originalLeft: 0,
+      width: 300
+    })
+  })
+
+  it('the item is on the right side clipped', () => {
+    let example = {
+      itemTimeStart: 700,
+      itemTimeEnd: 1000,
+      isDragging: false,
+      isResizing: false,
+      canvasTimeStart: 500,
+      canvasTimeEnd: 900,
+      canvasWidth: 400,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      fullUpdate: true,
+      visibleTimeStart: 500,
+      visibleTimeEnd: 900
+    }
+    expect(calculateDimensions(example)).toMatchObject({
+      clippedLeft: false,
+      clippedRight: true,
+      collisionLeft: 700,
+      collisionWidth: 300,
+      left: 200,
+      originalLeft: 700,
+      width: 200
+    })
+    // if we don't do the fullUpdate we don't get correct
+    // clipping informations
+    example.fullUpdate = false
+    expect(calculateDimensions(example)).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 700,
+      collisionWidth: 300,
+      left: 200,
+      originalLeft: 700,
+      width: 300
+    })
+  })
+
+  it('the item is draged', () => {
+    const dimension = calculateDimensions({
+      itemTimeStart: 200,
+      itemTimeEnd: 300,
+      isDragging: true,
+      isResizing: false,
+      canvasTimeStart: 0,
+      canvasTimeEnd: 500,
+      canvasWidth: 500,
+      dragSnap: 0,
+      dragTime: 300,
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      fullUpdate: true,
+      visibleTimeStart: 0,
+      visibleTimeEnd: 500
+    })
+
+    expect(dimension).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 200,
+      collisionWidth: 200,
+      left: 300,
+      originalLeft: 200,
+      width: 100
+    })
+  })
+
+  it('the item is resized right', () => {
+    const dimension = calculateDimensions({
+      itemTimeStart: 200,
+      itemTimeEnd: 300,
+      isDragging: false,
+      isResizing: true,
+      canvasTimeStart: 0,
+      canvasTimeEnd: 500,
+      canvasWidth: 500,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: true,
+      resizingEdge: 'right',
+      resizeTime: 250,
+      fullUpdate: true,
+      visibleTimeStart: 0,
+      visibleTimeEnd: 500
+    })
+
+    expect(dimension).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 200,
+      collisionWidth: 50,
+      left: 200,
+      originalLeft: 200,
+      width: 50
+    })
+  })
+
+  it('the item is resized left', () => {
+    const dimension = calculateDimensions({
+      itemTimeStart: 200,
+      itemTimeEnd: 300,
+      isDragging: false,
+      isResizing: true,
+      canvasTimeStart: 0,
+      canvasTimeEnd: 500,
+      canvasWidth: 500,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: true,
+      resizingEdge: 'left',
+      resizeTime: 210,
+      fullUpdate: true,
+      visibleTimeStart: 0,
+      visibleTimeEnd: 500
+    })
+
+    expect(dimension).toMatchObject({
+      clippedLeft: false,
+      clippedRight: false,
+      collisionLeft: 210,
+      collisionWidth: 90,
+      left: 210,
+      originalLeft: 200,
+      width: 90
+    })
+  })
+})

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -12,7 +12,6 @@ export default class Item extends Component {
     // canvasTimeStart: React.PropTypes.number.isRequired,
     // canvasTimeEnd: React.PropTypes.number.isRequired,
     // canvasWidth: React.PropTypes.number.isRequired,
-    // lineHeight: React.PropTypes.number.isRequired,
     // order: React.PropTypes.number.isRequired,
     //
     // dragSnap: React.PropTypes.number,
@@ -74,7 +73,6 @@ export default class Item extends Component {
                        nextProps.canvasTimeStart !== this.props.canvasTimeStart ||
                        nextProps.canvasTimeEnd !== this.props.canvasTimeEnd ||
                        nextProps.canvasWidth !== this.props.canvasWidth ||
-                       nextProps.lineHeight !== this.props.lineHeight ||
                        nextProps.order !== this.props.order ||
                        nextProps.dragSnap !== this.props.dragSnap ||
                        nextProps.minResizeWidth !== this.props.minResizeWidth ||

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -78,7 +78,6 @@ export default class Item extends Component {
                        nextProps.order !== this.props.order ||
                        nextProps.dragSnap !== this.props.dragSnap ||
                        nextProps.minResizeWidth !== this.props.minResizeWidth ||
-                       nextProps.selected !== this.props.selected ||
                        nextProps.canChangeGroup !== this.props.canChangeGroup ||
                        nextProps.canSelect !== this.props.canSelect ||
                        nextProps.topOffset !== this.props.topOffset ||

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -23,7 +23,6 @@ export default class Items extends Component {
     canvasTimeStart: PropTypes.number.isRequired,
     canvasTimeEnd: PropTypes.number.isRequired,
     canvasWidth: PropTypes.number.isRequired,
-    lineHeight: PropTypes.number.isRequired,
 
     dragSnap: PropTypes.number,
     minResizeWidth: PropTypes.number,
@@ -63,7 +62,6 @@ export default class Items extends Component {
              nextProps.canvasWidth === this.props.canvasWidth &&
              nextProps.selectedItem === this.props.selectedItem &&
              nextProps.selected === this.props.selected &&
-             nextProps.lineHeight === this.props.lineHeight &&
              nextProps.dragSnap === this.props.dragSnap &&
              nextProps.minResizeWidth === this.props.minResizeWidth &&
              nextProps.canChangeGroup === this.props.canChangeGroup &&
@@ -133,7 +131,6 @@ export default class Items extends Component {
                                         canvasTimeStart={this.props.canvasTimeStart}
                                         canvasTimeEnd={this.props.canvasTimeEnd}
                                         canvasWidth={this.props.canvasWidth}
-                                        lineHeight={this.props.lineHeight}
                                         dragSnap={this.props.dragSnap}
                                         minResizeWidth={this.props.minResizeWidth}
                                         onResizing={this.props.itemResizing}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -90,14 +90,23 @@ export function coordinateToTimeRatio (canvasTimeStart, canvasTimeEnd, canvasWid
   return (canvasTimeEnd - canvasTimeStart) / canvasWidth
 }
 
-export function calculateDimensions ({ item, order, keys, canvasTimeStart, canvasTimeEnd, canvasWidth, dragSnap, lineHeight, draggingItem, dragTime, resizingItem, resizingEdge, resizeTime, newGroupOrder, itemHeightRatio, fullUpdate, visibleTimeStart, visibleTimeEnd }) {
-  var itemId = _get(item, keys.itemIdKey)
-  var itemTimeStart = _get(item, keys.itemTimeStartKey)
-  var itemTimeEnd = _get(item, keys.itemTimeEndKey)
-
-  var isDragging = itemId === draggingItem
-  var isResizing = itemId === resizingItem
-
+export function calculateDimensions ({
+                                       itemTimeStart,
+                                       itemTimeEnd,
+                                       isDragging,
+                                       isResizing,
+                                       canvasTimeStart,
+                                       canvasTimeEnd,
+                                       canvasWidth,
+                                       dragSnap,
+                                       dragTime,
+                                       resizingItem,
+                                       resizingEdge,
+                                       resizeTime,
+                                       fullUpdate,
+                                       visibleTimeStart,
+                                       visibleTimeEnd
+                                     }) {
   const itemStart = (isResizing && resizingEdge === 'left' ? resizeTime : itemTimeStart)
   const itemEnd = (isResizing && resizingEdge === 'right' ? resizeTime : itemTimeEnd)
 
@@ -141,20 +150,13 @@ export function calculateDimensions ({ item, order, keys, canvasTimeStart, canva
   }
 
   const ratio = 1 / coordinateToTimeRatio(canvasTimeStart, canvasTimeEnd, canvasWidth)
-  const h = lineHeight * itemHeightRatio
 
   const dimensions = {
     left: (x - canvasTimeStart) * ratio,
-    top: null,
     width: Math.max(w * ratio, 3),
-    height: h,
-    order: isDragging ? newGroupOrder : order,
-    stack: !item.isOverlay,
     collisionLeft: collisionX,
     originalLeft: itemTimeStart,
     collisionWidth: collisionW,
-    lineHeight,
-    isDragging,
     clippedLeft,
     clippedRight
   }
@@ -215,16 +217,16 @@ export function stack (items, groupOrders, lineHeight, headerHeight, force) {
     var verticalMargin = 0
     for (i = 0, iMax = group.length; i < iMax; i++) {
       var item = group[i]
-      verticalMargin = (item.dimensions.lineHeight - item.dimensions.height)
+      verticalMargin = (lineHeight - item.dimensions.height)
 
       if (item.dimensions.stack && item.dimensions.top === null) {
         item.dimensions.top = totalHeight + verticalMargin
-        groupHeight = Math.max(groupHeight, item.dimensions.lineHeight)
+        groupHeight = Math.max(groupHeight, lineHeight)
         do {
           var collidingItem = null
           for (var j = 0, jj = group.length; j < jj; j++) {
             var other = group[j]
-            if (other.dimensions.top !== null && other !== item && other.dimensions.stack && collision(item.dimensions, other.dimensions, item.dimensions.lineHeight)) {
+            if (other.dimensions.top !== null && other !== item && other.dimensions.stack && collision(item.dimensions, other.dimensions, lineHeight)) {
               collidingItem = other
               break
             } else {
@@ -234,7 +236,7 @@ export function stack (items, groupOrders, lineHeight, headerHeight, force) {
 
           if (collidingItem != null) {
             // There is a collision. Reposition the items above the colliding element
-            item.dimensions.top = collidingItem.dimensions.top + collidingItem.dimensions.lineHeight
+            item.dimensions.top = collidingItem.dimensions.top + lineHeight
             groupHeight = Math.max(groupHeight, item.dimensions.top + item.dimensions.height - totalHeight)
           }
         } while (collidingItem)
@@ -274,11 +276,11 @@ export function nostack (items, groupOrders, lineHeight, headerHeight, force) {
     var groupHeight = 0
     for (i = 0, iMax = group.length; i < iMax; i++) {
       var item = group[i]
-      var verticalMargin = (item.dimensions.lineHeight - item.dimensions.height) / 2
+      var verticalMargin = (lineHeight - item.dimensions.height) / 2
 
       if (item.dimensions.top === null) {
         item.dimensions.top = totalHeight + verticalMargin
-        groupHeight = Math.max(groupHeight, item.dimensions.lineHeight)
+        groupHeight = Math.max(groupHeight, lineHeight)
       }
     }
     groupHeights[index] = Math.max(groupHeight, lineHeight)


### PR DESCRIPTION
I'm working on a function to have multiple Items drag at the same time. But for that I don't wanna mess with the `calculateDimensions`. Therefore I had a look at it and worked on some simplification and made it testable. 

_The following things were done in this PR:_
* no need to filter by valid dimension after `calculateDimensions`. Only add  if dimension is valid (`reduce instead` of `map` & `filter`)
* everything that is not pure calculation is taken out of the function so we don't need the keys in the `calculateDimensions`
* no round trips where we pass values in just go give it back then (like for `stack`)
* added tests

Beside the `lineHeight` I didn't do anything to the general handling. The `lineHeight` was just adjusted because we don't need to save it in each calculation. 

Over all it should be faster and hopefully more clear.