### PR TITLE
ADD: transform-runtime because Safari doesn't support Object.entries

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015", "stage-0", "react"],
   "plugins": [
-    "react-hot-loader/babel"
+    "react-hot-loader/babel",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-eslint": "^7.1.1",
     "babel-loader": "~6.2.4",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
Right now the Demo didn't work anymore on Safari for Mac because Object.entries is right now not supported (right now only in demo, but probably coming more and more). Maybe it's anyway better to have the runtime included to have a better browser support. I don't like it too much because the native functions are way cooler but I guess it's also nice to have it running on more browsers.