### PR TITLE
rename jsnext:main to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.11",
   "description": "react calendar timeline",
   "main": "lib/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.js",
   "scripts": {
     "build": "npm run build:lib",
     "build:demo": "echo '!!! Building Demo' && BABEL_ENV=react node build.js production",


### PR DESCRIPTION
According to [this page](https://www.reddit.com/r/javascript/comments/5jwg9c/confused_about_fields_module_and_jsnextmain_in/), the standard way to describe a `jsnext` entry point is through the `module` field in `package.json`, not `jsnext:main`. Updating to that
