### PR TITLE
Added stickyOffset

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -80,6 +80,7 @@ export default class ReactCalendarTimeline extends Component {
     dragSnap: PropTypes.number,
     minResizeWidth: PropTypes.number,
     fixedHeader: PropTypes.oneOf(['fixed', 'sticky', 'none']),
+	stickyOffset: PropTypes.number,
     fullUpdate: PropTypes.bool,
     lineHeight: PropTypes.number,
     headerLabelGroupHeight: PropTypes.number,
@@ -204,6 +205,7 @@ export default class ReactCalendarTimeline extends Component {
     dragSnap: 1000 * 60 * 15, // 15min
     minResizeWidth: 20,
     fixedHeader: 'sticky', // fixed or sticky or none
+	stickyOffset: 0,
     fullUpdate: true,
     lineHeight: 30,
     headerLabelGroupHeight: 30,
@@ -364,7 +366,7 @@ export default class ReactCalendarTimeline extends Component {
 
     const rect = this.refs.container.getBoundingClientRect()
 
-    if (rect.top > 0) {
+    if (rect.top > this.props.stickyOffset) {
       this.setState({ headerPosition: 'top' })
     } else if (rect.bottom < headerHeight) {
       this.setState({ headerPosition: 'bottom' })
@@ -942,6 +944,7 @@ export default class ReactCalendarTimeline extends Component {
               visibleTimeEnd={this.state.visibleTimeEnd}
               headerPosition={this.state.headerPosition}
               fixedHeader={this.props.fixedHeader}
+			  stickyOffset={this.props.stickyOffset}
               showPeriod={this.showPeriod}
               headerLabelFormats={this.props.headerLabelFormats}
               subHeaderLabelFormats={this.props.subHeaderLabelFormats} />
@@ -961,6 +964,7 @@ export default class ReactCalendarTimeline extends Component {
                headerHeight={headerHeight}
 
                headerPosition={this.state.headerPosition}
+			   stickyOffset={this.props.stickyOffset}
                fixedHeader={this.props.fixedHeader}>
         {this.props.sidebarContent}
       </Sidebar>
@@ -980,6 +984,7 @@ export default class ReactCalendarTimeline extends Component {
                headerHeight={headerHeight}
 
                headerPosition={this.state.headerPosition}
+			   stickyOffset={this.props.stickyOffset}
                fixedHeader={this.props.fixedHeader}>
         {this.props.rightSidebarContent}
       </Sidebar>

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -20,11 +20,13 @@ export default class Header extends Component {
     headerLabelFormats: PropTypes.object.isRequired,
     subHeaderLabelFormats: PropTypes.object.isRequired,
     fixedHeader: PropTypes.oneOf(['fixed', 'sticky', 'none']),
+	stickyOffset: PropTypes.number.isRequired,
     headerPosition: PropTypes.oneOf(['top', 'bottom', 'fixed'])
   }
 
   static defaultProps = {
     fixedHeader: 'sticky',
+	stickyOffset: 0,
     headerPosition: 'top'
   }
 
@@ -114,7 +116,7 @@ export default class Header extends Component {
     let timeLabels = []
     const {
       canvasTimeStart, canvasTimeEnd, canvasWidth, lineHeight,
-      visibleTimeStart, visibleTimeEnd, minUnit, timeSteps, fixedHeader, headerPosition,
+      visibleTimeStart, visibleTimeEnd, minUnit, timeSteps, fixedHeader, stickyOffset, headerPosition,
       headerLabelGroupHeight, headerLabelHeight, hasRightSidebar, width
     } = this.props
 
@@ -195,7 +197,7 @@ export default class Header extends Component {
         // do nothing, keep at the top
       } else if (headerPosition === 'fixed') {
         headerStyle.position = 'fixed'
-        headerStyle.top = 0
+        headerStyle.top = stickyOffset
         headerStyle.width = `${width}px`
       } else if (headerPosition === 'bottom') {
         headerStyle.position = 'absolute'

--- a/src/lib/layout/Sidebar.js
+++ b/src/lib/layout/Sidebar.js
@@ -11,6 +11,7 @@ export default class Sidebar extends Component {
     lineHeight: PropTypes.number.isRequired,
     groupHeights: PropTypes.array.isRequired,
     fixedHeader: PropTypes.oneOf(['fixed', 'sticky', 'none']),
+	stickyOffset: PropTypes.number.isRequired,
     headerPosition: PropTypes.oneOf(['top', 'bottom', 'fixed']),
     keys: PropTypes.object.isRequired,
     groupRenderer: PropTypes.func,
@@ -20,6 +21,7 @@ export default class Sidebar extends Component {
 
   static defaultProps = {
     fixedHeader: 'sticky',
+	stickyOffset: 0,
     headerPosition: 'top',
     children: null,
     isRightSidebar: false
@@ -31,6 +33,7 @@ export default class Sidebar extends Component {
              nextProps.width === this.props.width &&
              nextProps.lineHeight === this.props.lineHeight &&
              nextProps.fixedHeader === this.props.fixedHeader &&
+			 nextProps.stickyOffset === this.props.stickyOffset &&
              nextProps.headerPosition === this.props.headerPosition &&
              nextProps.groupHeights === this.props.groupHeights &&
              nextProps.height === this.props.height)
@@ -46,7 +49,7 @@ export default class Sidebar extends Component {
 
   render () {
     const {
-      fixedHeader, width, lineHeight, groupHeights, height, headerHeight, isRightSidebar, headerPosition
+      fixedHeader, stickyOffset, width, lineHeight, groupHeights, height, headerHeight, isRightSidebar, headerPosition
     } = this.props
 
     const {groupIdKey, groupTitleKey, groupRightTitleKey} = this.props.keys
@@ -74,7 +77,7 @@ export default class Sidebar extends Component {
         // do nothing - keep at the top
       } else if (headerPosition === 'fixed') {
         headerStyle.position = 'fixed'
-        headerStyle.top = 0
+        headerStyle.top = stickyOffset
         groupsStyle.paddingTop = headerStyle.height
       } else if (headerPosition === 'bottom') {
         headerStyle.position = 'absolute'


### PR DESCRIPTION
Hi, here you'll find my stickyOffset enhancement, see Issue #135 with some screenshots.

The motivation is the following: I have a Bootstrap Navbar scrolling up. At a certain point the Navbar is fixed in its position with a certain height. I want the calendar header scroll up and to be sticky up to the height of the Navbar.

=> API has to be adapted, below prop "fixedHeader" a new prop "stickyOffset": 
When fixedHeader is sticky (default) the stickyOffset value (default: 0) defines the distance from top where the header is fixed.

BR Kai