### PR TITLE
Left and right sidebar unification

### DIFF
--- a/src/lib/Timeline.scss
+++ b/src/lib/Timeline.scss
@@ -208,6 +208,7 @@ $weekend: rgba(250, 246, 225, 0.5);
     &.rct-sidebar-right {
       border-right: 0;
       border-left: $border-width solid $border-color;
+      float: right;
     }
 
     .rct-sidebar-header {

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -6,7 +6,6 @@ import { iterateTimes, getNextUnit } from '../utils.js'
 
 export default class Header extends Component {
   static propTypes = {
-    hasRightSidebar: PropTypes.bool.isRequired,
     showPeriod: PropTypes.func.isRequired,
     canvasTimeStart: PropTypes.number.isRequired,
     canvasTimeEnd: PropTypes.number.isRequired,
@@ -117,7 +116,7 @@ export default class Header extends Component {
     const {
       canvasTimeStart, canvasTimeEnd, canvasWidth, lineHeight,
       visibleTimeStart, visibleTimeEnd, minUnit, timeSteps, fixedHeader, stickyOffset, headerPosition,
-      headerLabelGroupHeight, headerLabelHeight, hasRightSidebar, width
+      headerLabelGroupHeight, headerLabelHeight, width
     } = this.props
 
     const ratio = canvasWidth / (canvasTimeEnd - canvasTimeStart)
@@ -140,7 +139,7 @@ export default class Header extends Component {
         timeLabels.push(
           <div key={`top-label-${time.valueOf()}`}
                href='#'
-               className={`rct-label-group${hasRightSidebar ? ' rct-has-right-sidebar' : ''}`}
+               className={'rct-label-group'}
                data-time={time}
                data-unit={nextUnit}
                style={{

--- a/src/lib/layout/Sidebar.js
+++ b/src/lib/layout/Sidebar.js
@@ -29,21 +29,21 @@ export default class Sidebar extends Component {
 
   shouldComponentUpdate (nextProps, nextState) {
     return !(arraysEqual(nextProps.groups, this.props.groups) &&
-             nextProps.keys === this.props.keys &&
-             nextProps.width === this.props.width &&
-             nextProps.lineHeight === this.props.lineHeight &&
-             nextProps.fixedHeader === this.props.fixedHeader &&
-             nextProps.stickyOffset === this.props.stickyOffset &&
-             nextProps.headerPosition === this.props.headerPosition &&
-             nextProps.groupHeights === this.props.groupHeights &&
-             nextProps.height === this.props.height)
+      nextProps.keys === this.props.keys &&
+      nextProps.width === this.props.width &&
+      nextProps.lineHeight === this.props.lineHeight &&
+      nextProps.fixedHeader === this.props.fixedHeader &&
+      nextProps.stickyOffset === this.props.stickyOffset &&
+      nextProps.headerPosition === this.props.headerPosition &&
+      nextProps.groupHeights === this.props.groupHeights &&
+      nextProps.height === this.props.height)
   }
 
-  renderGroupContent (group, isRightSidebar, groupTitleKey, groupRightTitleKey) {
+  renderGroupContent (group, isRightSidebar, groupTitleKey) {
     if (this.props.groupRenderer) {
       return React.createElement(this.props.groupRenderer, { group, isRightSidebar })
     } else {
-      return _get(group, isRightSidebar ? groupRightTitleKey : groupTitleKey)
+      return _get(group, groupTitleKey)
     }
   }
 
@@ -52,7 +52,9 @@ export default class Sidebar extends Component {
       fixedHeader, stickyOffset, width, lineHeight, groupHeights, height, headerHeight, isRightSidebar, headerPosition
     } = this.props
 
-    const {groupIdKey, groupTitleKey, groupRightTitleKey} = this.props.keys
+    const { groupIdKey } = this.props.keys
+
+    const groupTitleKey = this.props.sidebarKey
 
     const sidebarStyle = {
       width: `${width}px`,
@@ -87,8 +89,8 @@ export default class Sidebar extends Component {
     }
 
     const header = <div ref='sidebarHeader' className='rct-sidebar-header' style={headerStyle}>
-                     {this.props.children}
-                   </div>
+      {this.props.children}
+    </div>
 
     let groupLines = []
     let i = 0
@@ -101,7 +103,7 @@ export default class Sidebar extends Component {
 
       groupLines.push(
         <div key={_get(group, groupIdKey)} className={'rct-sidebar-row' + (i % 2 === 0 ? ' rct-sidebar-row-even' : ' rct-sidebar-row-odd')} style={elementStyle}>
-          {this.renderGroupContent(group, isRightSidebar, groupTitleKey, groupRightTitleKey)}
+          {this.renderGroupContent(group, isRightSidebar, groupTitleKey)}
         </div>
       )
       i += 1


### PR DESCRIPTION
Hi Marius, here you'll find the left and right sidebar unification with an option to add more than one sidebar to both sides. I'm relatively new to React, so any comments are very welcome.

In a nutshell I've added a `sidebars` array prop to the Timeline component which consists of:
id, sidebarWidth, sidebarContent, sidebarKey and isRightSidebar. So now you can add as many sidebars as you wish on both sides.

Thanks in advance.