### PR TITLE
Fix onCanvasClick when scrolled

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -79,7 +79,7 @@ export function getParentPosition (element) {
 
   while (element) {
     if (!element.offsetParent && element.tagName === 'BODY' && element.scrollLeft === 0 && element.scrollTop === 0) {
-      element = document.scrollingElement || element;
+      element = document.scrollingElement || element
     }
     xPosition += (element.offsetLeft - (first ? 0 : element.scrollLeft) + element.clientLeft)
     yPosition += (element.offsetTop - (first ? 0 : element.scrollTop) + element.clientTop)

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -78,6 +78,9 @@ export function getParentPosition (element) {
   var first = true
 
   while (element) {
+    if (!element.offsetParent && element.tagName === 'BODY' && element.scrollLeft === 0 && element.scrollTop === 0) {
+      element = document.scrollingElement || element;
+    }
     xPosition += (element.offsetLeft - (first ? 0 : element.scrollLeft) + element.clientLeft)
     yPosition += (element.offsetTop - (first ? 0 : element.scrollTop) + element.clientTop)
     element = element.offsetParent


### PR DESCRIPTION
When you scroll a page with the timeline, the onCanvasClick incorrectly determines the group/row for many browsers (Edge, Firefox, and Chrome 61). These browsers always return 0 for the body element's scrollTop property. Since the element.offsetParent bubbles up to the body element rather than the actual scrolling element, the onCanvasClick returns row/group as if the page was not scrolled. I mainly use chrome and didn't notice the issue till the latest chrome update.

Ideally offsetParent would return the scrolling element as the top level parent, but this was a quick solution that fixed the issue I was having. There may be better ways to solve. I tried to make it fall back to previous behavior if it didn't meet specific requirements.