### PR TITLE
fix for issue 168: tap on canvas does not create an item on mobile devices

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -446,6 +446,29 @@ export default class ReactCalendarTimeline extends Component {
     if (this.lastSingleTouch) {
       e.preventDefault()
 
+      // Ensure that no touchmove was effected
+      if ((this.lastSingleTouch.x === this.singleTouchStart.x) &&
+        (this.lastSingleTouch.y === this.singleTouchStart.y)) {
+        // Add clientX and clientY position to event so that groupId and time can be calculated
+        e.clientX = this.lastSingleTouch.x
+        e.clientY = this.lastSingleTouch.y
+        // Find out if tap was in scrollarea (below header) or not
+        let wasScrollAreaClick = false
+        let parentPosition = getParentPosition(e.currentTarget)
+        let screenY = this.lastSingleTouch.screenY
+        let headerHeight = this.props.headerLabelGroupHeight + this.props.headerLabelHeight
+        let stickyOffset = this.props.stickyOffset
+        let realOffset = parentPosition.y - screenY
+        if (realOffset > 0) {
+          wasScrollAreaClick = e.clientY > realOffset + headerHeight
+        } else {
+          wasScrollAreaClick = e.clientY > stickyOffset + headerHeight
+        }
+        if (wasScrollAreaClick) {
+          this.scrollAreaClick(e)
+        }
+      }
+
       this.lastSingleTouch = null
       this.singleTouchStart = null
     }


### PR DESCRIPTION
Touching an empty canvas cell on mobile devices did not trigger a new item. This fix resolves this issue.