### PR TITLE
use .getAttribute('class') instead of .className

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -325,9 +325,11 @@ export function getGroupedItems (items, groupOrders) {
   return arr
 }
 
-export function hasSomeParentTheClass (element, classname) {
-  if (element.className && element.className.split(' ').indexOf(classname) >= 0) return true
-  return element.parentNode && hasSomeParentTheClass(element.parentNode, classname)
+export function hasSomeParentTheClass (element, wantedClass) {
+  if (element.nodeType !== 1) return false
+  const actualClasses = element.getAttribute('class')
+  if (actualClasses && actualClasses.split(' ').indexOf(wantedClass) !== -1) return true
+  return hasSomeParentTheClass(element.parentNode, wantedClass)
 }
 
 export function deepObjectCompare (obj1, obj2) {


### PR DESCRIPTION
fixes:
```
Uncaught TypeError: e.className.split is not a function
    at y (utils.js:360)
    at t.value (Timeline.js:641)
    at t.D.scrollAreaClick (Timeline.js:1551)
```
e.g. when doing mouseUp on SVGElement child

see https://developer.mozilla.org/en-US/docs/Web/API/Element/className#Notes
> It is better to get/set the className of an element using Element.getAttribute and Element.setAttribute if you are dealing with SVG elements