### PR TITLE
Fix - incorrect time on onItem* events if outer timeline container has padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ When you submit a PR, add your changes here!
 
 ### Fixed
 - Fixed issue with state not properly updated when ending resize #173
+- Fixed issue with onItem* events not reporting correct time when timeline has outer padding #227
 
 ## 0.15.5
 

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -38,27 +38,27 @@ export default class App extends Component {
   }
 
   handleCanvasClick = (groupId, time, event) => {
-    console.log('Canvas clicked', groupId, time)
+    console.log('Canvas clicked', groupId, moment(time).format())
   }
 
   handleCanvasContextMenu = (group, time, e) => {
-    console.log('Canvas context menu', group, time)
+    console.log('Canvas context menu', group, moment(time).format())
   }
 
-  handleItemClick = (itemId) => {
-    console.log('Clicked: ' + itemId)
+  handleItemClick = (itemId, _, time) => {
+    console.log('Clicked: ' + itemId, moment(time).format())
   }
 
-  handleItemSelect = (itemId) => {
-    console.log('Selected: ' + itemId)
+  handleItemSelect = (itemId, _, time) => {
+    console.log('Selected: ' + itemId, moment(time).format())
   }
 
-  handleItemDoubleClick = (itemId) => {
-    console.log('Double Click: ' + itemId)
+  handleItemDoubleClick = (itemId, _, time) => {
+    console.log('Double Click: ' + itemId, moment(time).format())
   }
 
-  handleItemContextMenu = (itemId) => {
-    console.log('Context Menu: ' + itemId)
+  handleItemContextMenu = (itemId, _, time) => {
+    console.log('Context Menu: ' + itemId, moment(time).format())
   }
 
   handleItemMove = (itemId, dragTime, newGroupOrder) => {

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -667,13 +667,13 @@ export default class ReactCalendarTimeline extends Component {
   selectItem = (item, clickType, e) => {
     if (this.state.selectedItem === item || (this.props.itemTouchSendsClick && clickType === 'touch')) {
       if (item && this.props.onItemClick) {
-        const time = this.timeFromEvent(e)
+        const time = this.timeFromItemEvent(e)
         this.props.onItemClick(item, e, time)
       }
     } else {
       this.setState({selectedItem: item})
       if (item && this.props.onItemSelect) {
-        const time = this.timeFromEvent(e)
+        const time = this.timeFromItemEvent(e)
         this.props.onItemSelect(item, e, time)
       } else if (item === null && this.props.onItemDeselect) {
         this.props.onItemDeselect(e) // this isnt in the docs. Is this function even used?
@@ -683,27 +683,30 @@ export default class ReactCalendarTimeline extends Component {
 
   doubleClickItem = (item, e) => {
     if (this.props.onItemDoubleClick) {
-      const time = this.timeFromEvent(e)
+      const time = this.timeFromItemEvent(e)
       this.props.onItemDoubleClick(item, e, time)
     }
   }
 
   contextMenuClickItem = (item, e) => {
     if (this.props.onItemContextMenu) {
-      const time = this.timeFromEvent(e)
+      const time = this.timeFromItemEvent(e)
       this.props.onItemContextMenu(item, e, time)
     }
   }
 
-  rowAndTimeFromEvent = (e) => {
-    const { headerLabelGroupHeight, headerLabelHeight, dragSnap, sidebarWidth } = this.props
+  // TODO: this is very similar to timeFromItemEvent, aside from which element to get offsets
+  // from.  Look to consolidate the logic for determining coordinate to time
+  // as well as generalizing how we get time from click on the canvas
+  rowAndTimeFromScrollAreaEvent = (e) => {
+    const { headerLabelGroupHeight, headerLabelHeight, dragSnap } = this.props
     const { width, groupHeights, visibleTimeStart, visibleTimeEnd } = this.state
     const lineCount = _length(this.props.groups)
 
     // get coordinates relative to the component
     const parentPosition = getParentPosition(e.currentTarget)
 
-    const x = e.clientX - sidebarWidth
+    const x = e.clientX - parentPosition.x
     const y = e.clientY - parentPosition.y
 
     // calculate the y coordinate from `groupHeights` and header heights
@@ -722,8 +725,21 @@ export default class ReactCalendarTimeline extends Component {
     return [row, time]
   }
 
-  timeFromEvent = (e) => {
-    const [, time] = this.rowAndTimeFromEvent(e)
+  timeFromItemEvent = (e) => {
+    const { width, visibleTimeStart, visibleTimeEnd } = this.state
+    const { dragSnap } = this.props
+
+    const scrollComponent = this.refs.scrollComponent
+    const {x: scrollX} = scrollComponent.getBoundingClientRect()
+
+    const xRelativeToTimeline = e.clientX - scrollX
+
+    const relativeItemPosition = xRelativeToTimeline / width
+    const zoom = (visibleTimeEnd - visibleTimeStart)
+    const timeOffset = relativeItemPosition * zoom
+
+    let time = Math.round(visibleTimeStart + timeOffset)
+    time = Math.floor(time / dragSnap) * dragSnap
 
     return time
   }
@@ -735,7 +751,7 @@ export default class ReactCalendarTimeline extends Component {
       if (this.state.selectedItem) {
         this.selectItem(null)
       } else if (this.props.onCanvasClick) {
-        const [row, time] = this.rowAndTimeFromEvent(e)
+        const [row, time] = this.rowAndTimeFromScrollAreaEvent(e)
         if (row >= 0 && row < this.props.groups.length) {
           const groupId = _get(this.props.groups[row], this.props.keys.groupIdKey)
           this.props.onCanvasClick(groupId, time, e)


### PR DESCRIPTION
Fixes https://github.com/namespace-ee/react-calendar-timeline/issues/227