### PR TITLE
Fixing issue with wrong offsetTop in state after scroll

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -612,7 +612,7 @@ export default class ReactCalendarTimeline extends Component {
         }
       }
       if (e.deltaY !== 0) {
-        window.scrollTo(window.pageXOffset, window.pageYOffset + e.deltaY)
+        this.props.scrollableContainer.scrollTo(this.props.scrollableContainer.scrollLeft, this.props.scrollableContainer.scrollTop + e.deltaY)
         if (traditionalZoom) {
           const parentPosition = getParentPosition(e.currentTarget)
           const xPosition = e.clientX - parentPosition.x

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -367,6 +367,8 @@ export default class ReactCalendarTimeline extends Component {
     const headerHeight = headerLabelGroupHeight + headerLabelHeight
 
     const rect = this.refs.container.getBoundingClientRect()
+    const topOffset = rect.top + window.pageYOffset
+    this.setState({ topOffset })
 
     if (rect.top > this.props.stickyOffset) {
       this.setState({ headerPosition: 'top' })


### PR DESCRIPTION
Can be merged after this PR: https://github.com/namespace-ee/react-calendar-timeline/pull/199

Now if timeline is nested inside another div with overflow: scroll - it doesn't handle canvasDoubleClick and other click events correctly - because of the wrong offsetTop in state. We should listen to parent scroll and update offsetTop.