### PR TITLE
items isSelected to return boolean

### DIFF
--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -99,7 +99,7 @@ export default class Items extends Component {
       return this.props.selectedItem === _get(item, itemIdKey)
     } else {
       let target = _get(item, itemIdKey)
-      return this.props.selected.find(value => value === target)
+      return this.props.selected.includes(target)
     }
   }
 


### PR DESCRIPTION
item.selected is declared with propTypes to be a boolean. When I supply my own selected prop I get a proptype warning. This is because the isSelected function in the Items component returns a boolean only if there is no selected prop, the problem is that if an array of ids is supplied it returns selected.find() which will return what was found and not the boolean expected by Item.

Using includes instead  will return a boolean value