### PR TITLE
Fix snapping logic for case with timezone offset

### DIFF
--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -119,7 +119,7 @@ export default class Item extends Component {
   dragTimeSnap(dragTime, considerOffset) {
     const { dragSnap } = this.props
     if (dragSnap) {
-      const offset = considerOffset ? moment().utcOffset() * 60 * 1000 : 0
+      const offset = considerOffset ? moment(dragTime).utcOffset() * 60 * 1000 : 0
       return Math.round(dragTime / dragSnap) * dragSnap - offset % dragSnap
     } else {
       return dragTime


### PR DESCRIPTION
We should take utcOffset of dragTime otherwise it will respect current time offset, but it may change depending on date (summer/winter) time