### PR TITLE
236 - fixes issue where clicking/double clicking header calls canvas click/doubleClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ When you submit a PR, add your changes here!
 ### Fixed
 
 * propTypes error related to Item prop - #239
+  # onCanvasClick and onCanvasDoubleClick were being called on header click - #236
 
 ## 0.15.7
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Called when the item is clicked by the right button of the mouse. `time` is the 
 ### onCanvasClick(groupId, time, e)
 Called when an empty spot on the canvas was clicked. Get the group ID and the time as arguments. For example open a "new item" window after this.
 
-### onCanvasDoubleClick(groupId, time, e)
-Called when an empty spot on the canvas was double clicked. Get the group ID and the time as arguments.
+### onCanvasDoubleClick(group, time, e)
+Called when an empty spot on the canvas was double clicked. Get the group and the time as arguments.
 
 ### onCanvasContextMenu(group, time, e)
 Called when the canvas is clicked by the right button of the mouse. Note: If this property is set the default context menu doesn't appear

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -885,8 +885,13 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   scrollAreaClick = e => {
-    // if not clicking on an item
+    if (hasSomeParentTheClass(e.target, 'rct-header')) {
+      // don't do anything if we clicked on the header
+      // TODO: there should be a better way to handle this...
+      return
+    }
 
+    // if not clicking on an item
     if (!hasSomeParentTheClass(e.target, 'rct-item')) {
       if (this.state.selectedItem) {
         this.selectItem(null)

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1570,6 +1570,16 @@ export default class ReactCalendarTimeline extends Component {
             onMouseUp={this.handleMouseUp}
             onMouseLeave={this.handleMouseLeave}
           >
+            {this.header(
+              canvasTimeStart,
+              zoom,
+              canvasTimeEnd,
+              canvasWidth,
+              minUnit,
+              timeSteps,
+              headerLabelGroupHeight,
+              headerLabelHeight
+            )}
             <div
               ref={el => (this.canvasComponent = el)}
               className="rct-canvas"
@@ -1623,16 +1633,6 @@ export default class ReactCalendarTimeline extends Component {
                   )
                 : null}
               {this.infoLabel()}
-              {this.header(
-                canvasTimeStart,
-                zoom,
-                canvasTimeEnd,
-                canvasWidth,
-                minUnit,
-                timeSteps,
-                headerLabelGroupHeight,
-                headerLabelHeight
-              )}
               {this.childrenWithProps(
                 canvasTimeStart,
                 canvasTimeEnd,


### PR DESCRIPTION
https://github.com/namespace-ee/react-calendar-timeline/issues/236