### PR TITLE
Use left property of rect returned from getBoundingClientRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 When you submit a PR, add your changes here!
 
+### Fixed
+
+* fix issue with time report with onItem\* callbacks for browsers that don't support `x` property in rect object - #266
+
 ## 0.15.9
 
 ### Fixed

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -883,7 +883,7 @@ export default class ReactCalendarTimeline extends Component {
     const { dragSnap } = this.props
 
     const scrollComponent = this.scrollComponent
-    const { x: scrollX } = scrollComponent.getBoundingClientRect()
+    const { left: scrollX } = scrollComponent.getBoundingClientRect()
 
     const xRelativeToTimeline = e.clientX - scrollX
 


### PR DESCRIPTION
https://github.com/namespace-ee/react-calendar-timeline/issues/266