### PR TITLE
Minor speed/scrolling optimization

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1317,8 +1317,8 @@ export default class ReactCalendarTimeline extends Component {
 
     const visibleItems = getVisibleItems(
       items,
-      canvasTimeStart,
-      canvasTimeEnd,
+      visibleTimeStart,
+      visibleTimeEnd,
       keys
     )
     const groupOrders = getGroupOrders(groups, keys)

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -514,8 +514,7 @@ export default class Item extends Component {
       (dimensions.clippedRight ? ' clipped-right' : '')
 
     const style = {
-      left: `${dimensions.left}px`,
-      top: `${dimensions.top}px`,
+      transform: `translate3d(${dimensions.left}px, ${dimensions.top}px, 0)`,
       width: `${dimensions.width}px`,
       height: `${dimensions.height}px`,
       lineHeight: `${dimensions.height}px`

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -196,7 +196,7 @@ export default class Header extends Component {
               data-time={time}
               data-unit={nextUnit}
               style={{
-                left: `${left + leftCorrect}px`,
+                transform: `translate3d(${left + leftCorrect}px, 0, 0)`,
                 width: `${labelWidth}px`,
                 height: `${headerLabelGroupHeight}px`,
                 lineHeight: `${headerLabelGroupHeight}px`,

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -135,7 +135,7 @@ export default class Header extends Component {
     })
   }
 
-  render() {
+  componentDidUpdate() {
     let timeLabels = []
     const {
       canvasTimeStart,
@@ -286,6 +286,11 @@ export default class Header extends Component {
       }
     }
 
+    this.timeLabels = timeLabels
+    this.headerStyle = headerStyle
+  }
+
+  render() {
     return (
       <div
         key="header"
@@ -293,9 +298,9 @@ export default class Header extends Component {
         onTouchStart={this.touchStart}
         onTouchEnd={this.touchEnd}
         onClick={this.periodClick}
-        style={headerStyle}
+        style={this.headerStyle}
       >
-        {timeLabels}
+        {this.timeLabels}
       </div>
     )
   }

--- a/src/lib/lines/HorizontalLines.js
+++ b/src/lib/lines/HorizontalLines.js
@@ -29,8 +29,7 @@ export default class HorizontalLines extends Component {
           key={`horizontal-line-${i}`}
           className={i % 2 === 0 ? 'rct-hl-even' : 'rct-hl-odd'}
           style={{
-            top: `${totalHeight}px`,
-            left: '0px',
+            transform: `translate3d(0px, ${totalHeight}px, 0)`,
             width: `${canvasWidth}px`,
             height: `${groupHeights[i] - 1}px`
           }}

--- a/src/lib/lines/VerticalLines.js
+++ b/src/lib/lines/VerticalLines.js
@@ -78,8 +78,7 @@ export default class VerticalLines extends Component {
             key={`line-${time.valueOf()}`}
             className={classNames}
             style={{
-              top: `${headerHeight}px`,
-              left: `${left + leftPush}px`,
+              transform: `translate3d(${left + leftPush}px, ${headerHeight}px, 0)`,
               width: `${labelWidth}px`,
               height: `${height - headerHeight}px`
             }}


### PR DESCRIPTION
After basic testing via `npm start` I can safely say that it performs a lot better under pressure with 500+ groups. The vertical scrolling is a lot smoother if you scroll on top of the canvas, and horizontal scrolling is also much more consistent.

The main idea here is to use `transform` instead of `left/top`.
Also pass in visibleTime{Start/End} for calculating visible items.

Some more ideas in the future:
1. Memoize item components and async update between allowed timeframe for much more steady FPS while scrolling. (e.g. https://medium.com/@planttheidea/memoize-react-components-33377d7ebb6c)
2. Instead of setting scrollTo, perhaps wrap it in requestAnimationFrame so it will be prioritized at a more appropriate times in browser reflow/repaint cycle.
3. https://github.com/joshwnj/react-visibility-sensor for Item component with appropriate polling time period (I tried it locally and it doesn't work since you are using position absolute but however this is still a good idea to dive deeper)

Let me know if there are any questions about this commit. Hope this will be merged soon.

Cheers