### PR TITLE
Fix - Dragging items and canvas click

### DIFF
--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -50,6 +50,10 @@ export default class App extends Component {
     console.log('Canvas clicked', groupId, moment(time).format())
   }
 
+  handleCanvasDoubleClick = (groupId, time, event) => {
+    console.log('Canvas double clicked', groupId, moment(time).format())
+  }
+
   handleCanvasContextMenu = (group, time, e) => {
     console.log('Canvas context menu', group, moment(time).format())
   }
@@ -178,6 +182,7 @@ export default class App extends Component {
         // groupRenderer={this.groupRenderer}
 
         onCanvasClick={this.handleCanvasClick}
+        onCanvasDoubleClick={this.handleCanvasDoubleClick}
         onCanvasContextMenu={this.handleCanvasContextMenu}
         onItemClick={this.handleItemClick}
         onItemSelect={this.handleItemSelect}

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -358,7 +358,10 @@ export default class ReactCalendarTimeline extends Component {
       width: containerWidth,
       top: containerTop
     } = this.container.getBoundingClientRect()
+
     let width = containerWidth - props.sidebarWidth - props.rightSidebarWidth
+    const { headerLabelGroupHeight, headerLabelHeight } = props
+    const headerHeight = headerLabelGroupHeight + headerLabelHeight
 
     const { dimensionItems, height, groupHeights, groupTops } = this.stackItems(
       props.items,
@@ -369,13 +372,17 @@ export default class ReactCalendarTimeline extends Component {
       width
     )
 
+    // this is needed by dragItem since it uses pageY from the drag events
+    // if this was in the context of the scrollElement, this would not be necessary
+    const topOffset = containerTop + window.pageYOffset + headerHeight
+
     this.setState({
-      width: width,
-      topOffset: containerTop + window.pageYOffset,
-      dimensionItems: dimensionItems,
-      height: height,
-      groupHeights: groupHeights,
-      groupTops: groupTops
+      width,
+      topOffset,
+      dimensionItems,
+      height,
+      groupHeights,
+      groupTops
     })
     this.scrollComponent.scrollLeft = width
   }
@@ -638,7 +645,7 @@ export default class ReactCalendarTimeline extends Component {
   // from.  Look to consolidate the logic for determining coordinate to time
   // as well as generalizing how we get time from click on the canvas
   rowAndTimeFromScrollAreaEvent = e => {
-    const { headerLabelGroupHeight, headerLabelHeight, dragSnap } = this.props
+    const { dragSnap } = this.props
     const { width, groupHeights, visibleTimeStart, visibleTimeEnd } = this.state
     const lineCount = _length(this.props.groups)
 
@@ -650,7 +657,7 @@ export default class ReactCalendarTimeline extends Component {
 
     // calculate the y coordinate from `groupHeights` and header heights
     let row = 0
-    let remainingHeight = y - headerLabelGroupHeight - headerLabelHeight
+    let remainingHeight = y
 
     while (row < lineCount && remainingHeight - groupHeights[row] > 0) {
       remainingHeight -= groupHeights[row]


### PR DESCRIPTION
Bandaid to fix issue when dragging item on canvas.  This was a regression related to removing references to header height.  topOffset needs to be a function of container top, scroll offset AND header height.  This is because dragging item event looks at pageY, not the scroll element.