### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ At the very minimum:
 ```jsx
 import Timeline from 'react-calendar-timeline'
 // make sure you include the timeline stylesheet or the timeline will not be styled
-import 'react-calender-timeline/lib/Timeline.css'
+import 'react-calendar-timeline/lib/Timeline.css'
 import moment from 'moment'
 
 const groups = [{ id: 1, title: 'group 1' }, { id: 2, title: 'group 2' }]


### PR DESCRIPTION
The typo calender -> calendar.