### PR TITLE
Refactor multiselect with 0.16.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### Breaking
+* canSelect propType no longer boolean, must be one of "none", "single", "multi". Defaults to "single" for backwards compatibility
+
+### Added
+* multi select of items
+
+
 ### 0.16.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 ## Unreleased
 
 ### Breaking
-* canSelect propType no longer boolean, must be one of "none", "single", "multi". Defaults to "single" for backwards compatibility
+* canSelect, onItemSelect, onItemDeselect removed
+* Removed internal state of selected items. Selected items must now be passed in via props (selected) and selection/deselection managed by the user.
 
 ### Added
 * multi select of items
 
+### Removed
+* onItemSelect callback prop
+* onItemDeselect callback prop
+* canSelect prop
+* selectedItems (not user facing)
 
 ### 0.16.1
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The exact viewport of the calendar. When these are specified, scrolling in the c
 
 ### selected
 
-An array with id's corresponding to id's in items (`item.id`). If this prop is set you have to manage the selected items yourself within the `onItemSelect` handler to update the property with new id's. This overwrites the default behaviour of selecting one item on click.
+An array with id's corresponding to id's in items (`item.id`). If this prop is set you need to managed the state of the selected items via `onItemClick` or some other external widget. Leaving this option out or setting to an empty array effectively turns the timeline readonly 
 
 ### keys
 
@@ -209,11 +209,13 @@ Largest time the calendar can zoom to in milliseconds. Default `5 * 365.24 * 864
 
 ### clickTolerance
 
-How many pixels we can drag the background for it to be counted as a click on the background. Defualt: `3`
+How many pixels we can drag the background for it to be counted as a click on the background. Default: `3`
 
 ### canMove
 
 Can items be dragged around? Can be overridden in the `items` array. Defaults to `true`
+
+Note: for this to work, the item(s) need to be present within the `selected` prop.
 
 ### canChangeGroup
 
@@ -241,7 +243,7 @@ Zoom in when scrolling the mouse up/down. Defaults to `false`
 
 ### itemTouchSendsClick
 
-Normally tapping (touching) an item selects it. If this is set to true, a tap will have the same effect, as selecting with the first click and then clicking again to open and send the onItemClick event. Defaults to `false`.
+Normally tapping (touching) an item selects it. If this is set to true, a tap will have the same effect, as selecting with the first click and then clicking again to open and send the `onItemClick` event. Defaults to `false`.
 
 ### timeSteps
 
@@ -260,17 +262,19 @@ Default:
 }
 ```
 
-### onItemMove(itemId, dragTime, newGroupOrder)
+### onItemMove(item, dragTime, newGroupOrder)
 
-Callback when an item is moved. Returns 1) the item's ID, 2) the new start time and 3) the index of the new group in the `groups` array.
+Callback when an item is moved. Returns 1) the item , 2) the drag offset time relative to the start time of the object and 3) the index of the new group in the `groups` array.
+
+Note: In the case of multi-selected movements, the parameters returned are from the item that was physically interacted with during the move event. 
+
+See the multiselect demo for applying these changes to the other selected items in the group.
+
 
 ### onItemResize(itemId, time, edge)
 
 Callback when an item is resized. Returns 1) the item's ID, 2) the new start or end time of the item 3) The edge that was dragged (`left` or `right`)
 
-### onItemSelect(itemId, e, time)
-
-Called when an item is selected. This is sent on the first click on an item. `time` is the time that corresponds to where you click/select on the item in the timeline.
 
 ### onItemClick(itemId, e, time)
 

--- a/demo/app/demo-element-resize/index.js
+++ b/demo/app/demo-element-resize/index.js
@@ -40,8 +40,47 @@ export default class App extends Component {
       items,
       defaultTimeStart,
       defaultTimeEnd,
-      width
+      width,
+      selected: []
     }
+  }
+
+  handleCanvasClick = (groupId, time, event) => {
+    console.log('Canvas clicked', groupId, moment(time).format())
+
+    this.setState({selected: []});
+  }
+
+  handleItemClick = (itemId, _, time) => {
+    console.log('Clicked: ' + itemId, moment(time).format())
+
+    const isSelected = this.state.selected.indexOf(itemId) > -1;
+
+    this.setState({
+      selected: isSelected ? []: [itemId] 
+    })
+  }
+
+  handleItemMove = (item, dragTime, newGroupOrder) => {
+    console.log('Item moved: ', item, dragTime);
+    const { items, groups } = this.state
+
+    const group = groups[newGroupOrder]
+
+    this.setState({
+      items: items.map(
+        i =>
+          i.id === item.id
+            ? Object.assign({}, item, {
+                start: i.start + dragTime,
+                end: i.end + dragTime,
+                group: group.id
+              })
+            : i
+      )
+    })
+
+    console.log('Moved', item, dragTime, newGroupOrder)
   }
 
   render() {
@@ -66,7 +105,7 @@ export default class App extends Component {
             rightSidebarContent={<div>Above The Right</div>}
             canMove
             canResize="right"
-            canSelect
+            selected={this.state.selected}
             itemsSorted
             itemTouchSendsClick={false}
             stackItems
@@ -75,6 +114,9 @@ export default class App extends Component {
             resizeDetector={containerResizeDetector}
             defaultTimeStart={defaultTimeStart}
             defaultTimeEnd={defaultTimeEnd}
+            onCanvasClick={this.handleCanvasClick}
+            onItemClick={this.handleItemClick}
+            onItemMove={this.handleItemMove}
           />
         </div>
         <div style={{ width: `${100 - width}%`, float: 'left' }}>

--- a/demo/app/demo-linked-timelines/index.js
+++ b/demo/app/demo-linked-timelines/index.js
@@ -73,7 +73,6 @@ export default class App extends Component {
         sidebarContent={<div>Above The Left</div>}
         canMove
         canResize="right"
-        canSelect
         itemsSorted
         itemTouchSendsClick={false}
         stackItems
@@ -97,7 +96,6 @@ export default class App extends Component {
         sidebarContent={<div>Above The Left</div>}
         canMove
         canResize="right"
-        canSelect
         itemsSorted
         itemTouchSendsClick={false}
         stackItems

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -42,12 +42,15 @@ export default class App extends Component {
       groups,
       items,
       defaultTimeStart,
-      defaultTimeEnd
+      defaultTimeEnd,
+      selected: []
     }
   }
 
   handleCanvasClick = (groupId, time, event) => {
     console.log('Canvas clicked', groupId, moment(time).format())
+
+    this.setState({selected: []});
   }
 
   handleCanvasDoubleClick = (groupId, time, event) => {
@@ -60,10 +63,12 @@ export default class App extends Component {
 
   handleItemClick = (itemId, _, time) => {
     console.log('Clicked: ' + itemId, moment(time).format())
-  }
 
-  handleItemSelect = (itemId, _, time) => {
-    console.log('Selected: ' + itemId, moment(time).format())
+    const isSelected = this.state.selected.indexOf(itemId) > -1;
+
+    this.setState({
+      selected: isSelected ? []: [itemId] 
+    })
   }
 
   handleItemDoubleClick = (itemId, _, time) => {
@@ -74,25 +79,26 @@ export default class App extends Component {
     console.log('Context Menu: ' + itemId, moment(time).format())
   }
 
-  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+  handleItemMove = (item, dragTime, newGroupOrder) => {
+    console.log('Item moved: ', item, dragTime);
     const { items, groups } = this.state
 
     const group = groups[newGroupOrder]
 
     this.setState({
       items: items.map(
-        item =>
-          item.id === itemId
+        i =>
+          i.id === item.id
             ? Object.assign({}, item, {
-                start: dragTime,
-                end: dragTime + (item.end - item.start),
+                start: i.start + dragTime,
+                end: i.end + dragTime,
                 group: group.id
               })
-            : item
+            : i
       )
     })
 
-    console.log('Moved', itemId, dragTime, newGroupOrder)
+    console.log('Moved', item, dragTime, newGroupOrder)
   }
 
   handleItemResize = (itemId, time, edge) => {
@@ -154,7 +160,7 @@ export default class App extends Component {
   // }
 
   render() {
-    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+    const { groups, items, defaultTimeStart, defaultTimeEnd, selected } = this.state
 
     return (
       <Timeline
@@ -165,10 +171,9 @@ export default class App extends Component {
         sidebarContent={<div>Above The Left</div>}
         // rightSidebarWidth={150}
         // rightSidebarContent={<div>Above The Right</div>}
-
+        selected={selected}
         canMove
         canResize="right"
-        canSelect
         itemsSorted
         itemTouchSendsClick={false}
         stackItems
@@ -185,7 +190,6 @@ export default class App extends Component {
         onCanvasDoubleClick={this.handleCanvasDoubleClick}
         onCanvasContextMenu={this.handleCanvasContextMenu}
         onItemClick={this.handleItemClick}
-        onItemSelect={this.handleItemSelect}
         onItemContextMenu={this.handleItemContextMenu}
         onItemMove={this.handleItemMove}
         onItemResize={this.handleItemResize}

--- a/demo/app/demo-multiselect/index.js
+++ b/demo/app/demo-multiselect/index.js
@@ -106,9 +106,15 @@ export default class App extends Component {
     console.log('Context Menu: ' + itemId)
   }
 
-  handleItemMove = (itemId, dragTime, newGroupOrder) => {
-    console.log('item moved');
 
+  calcNewGroupOrder = (orderOffset, groups, groupId) => {
+
+    const rawGroupOrder = groups.findIndex( g => g.id == groupId) + orderOffset;
+
+    return orderOffset < 0 ? Math.min(0, rawGroupOrder) : Math.min(rawGroupOrder, groups.length -1);
+  }
+
+  handleItemMove = (itemId, dragTime, newGroupOrder) => {
     const { items, groups, selected } = this.state;
 
     const group = groups[newGroupOrder];
@@ -118,16 +124,19 @@ export default class App extends Component {
 
     // The net offset will be negative for moving up
     const orderOffset = newGroupOrder - oldGroupOrder;
+    
+    console.log('Moved', itemId, dragTime, group, newGroupOrder, oldGroupOrder, orderOffset)
 
     this.setState({
-      items: items.map(item => selected.indexOf(item.id) > -1 ? Object.assign({}, item, {
+      items: items.map(item => (
+        selected.indexOf(item.id) > -1 ? Object.assign({}, item, {
         start: item.start + dragTime,
         end:  item.end + dragTime,
-        group: groups[groups.findIndex( g => g.id ==item.group) + orderOffset].id
-      }) : item)
-    })
+        group: groups[this.calcNewGroupOrder(orderOffset, groups, item.group)].id
+      }) : item )
+      )
+    });
 
-    console.log('Moved', itemId, dragTime, group, newGroupOrder, oldGroupOrder, orderOffset)
   }
 
   handleItemResize = (itemId, time, edge) => {

--- a/demo/app/demo-multiselect/index.js
+++ b/demo/app/demo-multiselect/index.js
@@ -29,6 +29,10 @@ export default class App extends Component {
       {
         id: 3,
         title: 'Group C'
+      },
+      {
+        id: 4,
+        title: 'Group D'
       }
     ]
     let items = [
@@ -55,7 +59,15 @@ export default class App extends Component {
         id: 3,
         title: 'Item C',
         canResize: 'both'
-      }
+      },
+      {
+        start: moment().add(-2, 'hours'),
+        end: moment().add(2, 'hours'),
+        group: 4,
+        id: 4,
+        title: 'Item D',
+        canResize: 'both'
+      },
     ]
 
     const defaultTimeStart = moment().startOf('day').toDate()
@@ -70,36 +82,41 @@ export default class App extends Component {
     }
   }
 
-  handleCanvasClick = (groupId, time, event) => {
+  handleCanvasClick = (groupId, time, e) => {
     console.log('Canvas clicked', groupId, time)
+
+    // Deselect all items
+    this.setState({
+      selected: []
+    });
   }
 
   handleCanvasContextMenu = (group, time, e) => {
     console.log('Canvas context menu', group, time)
   }
 
-  handleItemClick = (itemId) => {
+  handleItemClick = (itemId, e, time) => {
+    console.log('Parent Clicked: ' + itemId)
+
+    // If item is currently selected, then deselect it and vice versa
+    const isSelected = this.state.selected.indexOf(itemId) > -1;
+
+    let newSelected = this.state.selected.slice();
+
+    if( isSelected) {
+      newSelected = this.state.selected.filter(id => id !== itemId)
+    } else {
+      newSelected.push(itemId)
+    }
+
     this.setState({
-      selected: this.state.selected.filter(id => id !== itemId)
+      selected: newSelected
     })
 
-    console.log('Clicked: ' + itemId)
   }
 
-  handleItemSelect = (itemId) => {
-    let selected = this.state.selected.slice()
-    selected.push(itemId)
-    this.setState({
-      selected
-    })
-    console.log('Selected: ' + itemId)
-  }
-
-  handleItemDeselect = () => {
-    this.setState({
-      selected: []
-    })
-    console.log('Deselected all')
+  handleItemDoubleClick = (itemId) => {
+    console.log('Parent double click', itemId);
   }
 
   handleItemContextMenu = (itemId) => {
@@ -110,8 +127,8 @@ export default class App extends Component {
   calcNewGroupOrder = (orderOffset, groups, groupId) => {
 
     const rawGroupOrder = groups.findIndex( g => g.id == groupId) + orderOffset;
-
-    return orderOffset < 0 ? Math.min(0, rawGroupOrder) : Math.min(rawGroupOrder, groups.length -1);
+    
+    return orderOffset < 0 ? Math.max(0, rawGroupOrder) : Math.min(rawGroupOrder, groups.length -1);
   }
 
   handleItemMove = (itemId, dragTime, newGroupOrder) => {
@@ -153,7 +170,7 @@ export default class App extends Component {
   }
 
   render () {
-    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+    const { groups, items, defaultTimeStart, defaultTimeEnd, selected } = this.state
 
     return (
       <Timeline groups={groups}
@@ -168,7 +185,7 @@ export default class App extends Component {
                 canMove
                 canResize='both'
                 useResizeHandle
-                canSelect
+                // selectMode="multi"
 
                 itemsSorted
                 itemTouchSendsClick={false}
@@ -180,15 +197,14 @@ export default class App extends Component {
                 defaultTimeStart={defaultTimeStart}
                 defaultTimeEnd={defaultTimeEnd}
 
-                selected={this.state.selected}
+                selected={selected}
                 canChangeGroup={true}
 
                 onCanvasClick={this.handleCanvasClick}
                 onCanvasContextMenu={this.handleCanvasContextMenu}
 
                 onItemClick={this.handleItemClick}
-                onItemSelect={this.handleItemSelect}
-                onItemDeselect={this.handleItemDeselect}
+                onItemDoubleClick={this.handleItemDoubleClick}
                 onItemContextMenu={this.handleItemContextMenu}
                 onItemMove={this.handleItemMove}
                 onItemResize={this.handleItemResize}

--- a/demo/app/demo-multiselect/index.js
+++ b/demo/app/demo-multiselect/index.js
@@ -131,26 +131,26 @@ export default class App extends Component {
     return orderOffset < 0 ? Math.max(0, rawGroupOrder) : Math.min(rawGroupOrder, groups.length -1);
   }
 
-  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+  handleItemMove = (item, dragTime, newGroupOrder) => {
     const { items, groups, selected } = this.state;
 
     const group = groups[newGroupOrder];
 
     // calculate the overall group change for all selected items
-    const oldGroupOrder = groups.findIndex( g => g.id == itemId.group);
+    const oldGroupOrder = groups.findIndex( g => g.id == item.group);
 
     // The net offset will be negative for moving up
     const orderOffset = newGroupOrder - oldGroupOrder;
     
-    console.log('Moved', itemId, dragTime, group, newGroupOrder, oldGroupOrder, orderOffset)
+    console.log('Moved', item, dragTime, group, newGroupOrder, oldGroupOrder, orderOffset)
 
     this.setState({
-      items: items.map(item => (
-        selected.indexOf(item.id) > -1 ? Object.assign({}, item, {
-        start: item.start + dragTime,
-        end:  item.end + dragTime,
-        group: groups[this.calcNewGroupOrder(orderOffset, groups, item.group)].id
-      }) : item )
+      items: items.map(i => (
+        selected.indexOf(i.id) > -1 ? Object.assign({}, i, {
+        start: i.start + dragTime,
+        end:  i.end + dragTime,
+        group: groups[this.calcNewGroupOrder(orderOffset, groups, i.group)].id
+      }) : i )
       )
     });
 

--- a/demo/app/demo-multiselect/index.js
+++ b/demo/app/demo-multiselect/index.js
@@ -1,0 +1,189 @@
+import React, { Component } from 'react'
+import moment from 'moment'
+import Timeline from 'react-calendar-timeline'
+
+var keys = {
+  groupIdKey: 'id',
+  groupTitleKey: 'title',
+  itemIdKey: 'id',
+  itemTitleKey: 'title',
+  itemDivTitleKey: 'title',
+  itemGroupKey: 'group',
+  itemTimeStartKey: 'start',
+  itemTimeEndKey: 'end'
+}
+
+export default class App extends Component {
+  constructor (props) {
+    super(props)
+
+    let groups = [
+      {
+        id: 1,
+        title: 'Group A'
+      },
+      {
+        id: 2,
+        title: 'Group B'
+      },
+      {
+        id: 3,
+        title: 'Group C'
+      }
+    ]
+    let items = [
+      {
+        start: moment().add(-2, 'hours'),
+        end: moment().add(2, 'hours'),
+        group: 1,
+        id: 1,
+        title: 'Item A',
+        canResize: 'both'
+      },
+      {
+        start: moment().add(-6, 'hours'),
+        end: moment().add(-2, 'hours'),
+        group: 2,
+        id: 2,
+        title: 'Item B',
+        canResize: 'both'
+      },
+      {
+        start: moment().add(-6, 'hours'),
+        end: moment().add(-2, 'hours'),
+        group: 3,
+        id: 3,
+        title: 'Item C',
+        canResize: 'both'
+      }
+    ]
+
+    const defaultTimeStart = moment().startOf('day').toDate()
+    const defaultTimeEnd = moment().startOf('day').add(1, 'day').toDate()
+
+    this.state = {
+      groups,
+      items,
+      defaultTimeStart,
+      defaultTimeEnd,
+      selected: [1, 2]
+    }
+  }
+
+  handleCanvasClick = (groupId, time, event) => {
+    console.log('Canvas clicked', groupId, time)
+  }
+
+  handleCanvasContextMenu = (group, time, e) => {
+    console.log('Canvas context menu', group, time)
+  }
+
+  handleItemClick = (itemId) => {
+    this.setState({
+      selected: this.state.selected.filter(id => id !== itemId)
+    })
+
+    console.log('Clicked: ' + itemId)
+  }
+
+  handleItemSelect = (itemId) => {
+    let selected = this.state.selected.slice()
+    selected.push(itemId)
+    this.setState({
+      selected
+    })
+    console.log('Selected: ' + itemId)
+  }
+
+  handleItemDeselect = () => {
+    this.setState({
+      selected: []
+    })
+    console.log('Deselected all')
+  }
+
+  handleItemContextMenu = (itemId) => {
+    console.log('Context Menu: ' + itemId)
+  }
+
+  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+    console.log('item moved');
+
+    const { items, groups, selected } = this.state;
+
+    const group = groups[newGroupOrder];
+
+    // calculate the overall group change for all selected items
+    const oldGroupOrder = groups.findIndex( g => g.id == itemId.group);
+
+    // The net offset will be negative for moving up
+    const orderOffset = newGroupOrder - oldGroupOrder;
+
+    this.setState({
+      items: items.map(item => selected.indexOf(item.id) > -1 ? Object.assign({}, item, {
+        start: item.start + dragTime,
+        end:  item.end + dragTime,
+        group: groups[groups.findIndex( g => g.id ==item.group) + orderOffset].id
+      }) : item)
+    })
+
+    console.log('Moved', itemId, dragTime, group, newGroupOrder, oldGroupOrder, orderOffset)
+  }
+
+  handleItemResize = (itemId, time, edge) => {
+    const { items } = this.state
+
+    this.setState({
+      items: items.map(item => item.id === itemId ? Object.assign({}, item, {
+        start: edge === 'left' ? time : item.start,
+        end: edge === 'left' ? item.end : time
+      }) : item)
+    })
+
+    console.log('Resized', itemId, time, edge)
+  }
+
+  render () {
+    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+
+    return (
+      <Timeline groups={groups}
+                items={items}
+                keys={keys}
+                fixedHeader='fixed'
+                fullUpdate
+
+                sidebarWidth={150}
+                sidebarContent={<div>Above The Left</div>}
+
+                canMove
+                canResize='both'
+                useResizeHandle
+                canSelect
+
+                itemsSorted
+                itemTouchSendsClick={false}
+                stackItems
+                itemHeightRatio={0.75}
+
+                showCursorLine
+
+                defaultTimeStart={defaultTimeStart}
+                defaultTimeEnd={defaultTimeEnd}
+
+                selected={this.state.selected}
+                canChangeGroup={true}
+
+                onCanvasClick={this.handleCanvasClick}
+                onCanvasContextMenu={this.handleCanvasContextMenu}
+
+                onItemClick={this.handleItemClick}
+                onItemSelect={this.handleItemSelect}
+                onItemDeselect={this.handleItemDeselect}
+                onItemContextMenu={this.handleItemContextMenu}
+                onItemMove={this.handleItemMove}
+                onItemResize={this.handleItemResize}
+      />
+    )
+  }
+}

--- a/demo/app/demo-performance/index.js
+++ b/demo/app/demo-performance/index.js
@@ -41,12 +41,15 @@ export default class App extends Component {
       groups,
       items,
       defaultTimeStart,
-      defaultTimeEnd
+      defaultTimeEnd,
+      selected: []
     }
   }
 
   handleCanvasClick = (groupId, time, event) => {
     console.log('Canvas clicked', groupId, moment(time).format())
+    
+    this.setState({selected: []});
   }
 
   handleCanvasContextMenu = (group, time, e) => {
@@ -55,6 +58,12 @@ export default class App extends Component {
 
   handleItemClick = (itemId, _, time) => {
     console.log('Clicked: ' + itemId, moment(time).format())
+
+    const isSelected = this.state.selected.indexOf(itemId) > -1;
+
+    this.setState({
+      selected: isSelected ? []: [itemId] 
+    })
   }
 
   handleItemSelect = (itemId, _, time) => {
@@ -69,25 +78,26 @@ export default class App extends Component {
     console.log('Context Menu: ' + itemId, moment(time).format())
   }
 
-  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+  handleItemMove = (item, dragTime, newGroupOrder) => {
+    console.log('Item moved: ', item, dragTime, newGroupOrder);
     const { items, groups } = this.state
 
     const group = groups[newGroupOrder]
 
     this.setState({
       items: items.map(
-        item =>
-          item.id === itemId
+        i =>
+          i.id === item.id
             ? Object.assign({}, item, {
-                start: dragTime,
-                end: dragTime + (item.end - item.start),
+                start: i.start + dragTime,
+                end: i.end + dragTime,
                 group: group.id
               })
-            : item
+            : i
       )
     })
 
-    console.log('Moved', itemId, dragTime, newGroupOrder)
+    console.log('Moved', item, dragTime, newGroupOrder)
   }
 
   handleItemResize = (itemId, time, edge) => {
@@ -149,7 +159,7 @@ export default class App extends Component {
   // }
 
   render() {
-    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+    const { groups, items, defaultTimeStart, defaultTimeEnd, selected } = this.state
 
     return (
       <Timeline
@@ -163,7 +173,7 @@ export default class App extends Component {
 
         canMove
         canResize="right"
-        canSelect
+        selected={selected}
         itemsSorted
         itemTouchSendsClick={false}
         stackItems
@@ -179,7 +189,6 @@ export default class App extends Component {
         onCanvasClick={this.handleCanvasClick}
         onCanvasContextMenu={this.handleCanvasContextMenu}
         onItemClick={this.handleItemClick}
-        onItemSelect={this.handleItemSelect}
         onItemContextMenu={this.handleItemContextMenu}
         onItemMove={this.handleItemMove}
         onItemResize={this.handleItemResize}

--- a/demo/app/demo-plugins/index.js
+++ b/demo/app/demo-plugins/index.js
@@ -96,10 +96,6 @@ export default class App extends Component {
           keys={keys}
           sidebarWidth={150}
           sidebarContent={<div>Above The Left</div>}
-          canMove
-          canResize="right"
-          canSelect
-          itemsSorted
           itemTouchSendsClick={false}
           stackItems
           itemHeightRatio={0.75}

--- a/demo/app/demo-sticky-header/index.js
+++ b/demo/app/demo-sticky-header/index.js
@@ -60,10 +60,6 @@ export default class App extends Component {
           sidebarContent={<div>Above The Left</div>}
           rightSidebarWidth={150}
           rightSidebarContent={<div>Above The Right</div>}
-          canMove
-          canResize="right"
-          canSelect
-          itemsSorted
           itemTouchSendsClick={false}
           stackItems
           itemHeightRatio={0.75}
@@ -109,10 +105,6 @@ export default class App extends Component {
           sidebarContent={<div>Above The Left</div>}
           rightSidebarWidth={150}
           rightSidebarContent={<div>Above The Right</div>}
-          canMove
-          canResize="right"
-          canSelect
-          itemsSorted
           itemTouchSendsClick={false}
           stackItems
           itemHeightRatio={0.75}

--- a/demo/app/demo-tree-groups/index.js
+++ b/demo/app/demo-tree-groups/index.js
@@ -100,7 +100,8 @@ export default class App extends Component {
         rightSidebarContent={<div>Above The Right</div>}
         canMove
         canResize="right"
-        canSelect
+        // Effectively readonly
+        selected={[]}
         itemsSorted
         itemTouchSendsClick={false}
         stackItems

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -12,7 +12,8 @@ const demos = {
   linkedTimelines: require('./demo-linked-timelines').default,
   elementResize: require('./demo-element-resize').default,
   plugins: require('./demo-plugins').default,
-  stickyHeader: require('./demo-sticky-header').default
+  stickyHeader: require('./demo-sticky-header').default,
+  multiselect: require('./demo-multiselect').default
 }
 
 // A simple component that shows the pathname of the current location

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -63,8 +63,7 @@ export default class Item extends Component {
       interactMounted: false,
 
       dragging: null,
-      dragStart: null,
-      preDragPosition: null,
+      dragStartPos: null,
       dragTime: null,
       dragGroupDelta: null,
 
@@ -139,11 +138,65 @@ export default class Item extends Component {
     }
   }
 
+  dragstart (e) {
+    if (this.props.onDragStart) {
+      this.props.onDragStart(this.itemId)
+    }
+    this.setState({
+      dragging: true,
+      dragStartPos: {x: e.pageX, y: e.pageY},
+      dragGroupDelta: 0
+    })
+  }
+
+  dragmove (e) {
+    const { onDrag, dragSnap, item } = this.props
+    let dragTimeDelta = this.dragTimeDelta(e)
+    let dragGroupDelta = this.dragGroupDelta(e)
+
+    if (this.props.moveResizeValidator) {
+      dragTimeDelta = this.props.moveResizeValidator('move', item, this.itemTimeStart + dragTimeDelta) - this.itemTimeStart
+    } else {
+      dragTimeDelta = (Math.round((this.itemTimeStart + dragTimeDelta) / dragSnap) * dragSnap) - this.itemTimeStart
+    }
+
+    if (onDrag) {
+      onDrag(item, dragTimeDelta, this.props.order, dragGroupDelta)
+    }
+
+    this.setState({
+      dragTimeDelta,
+      dragGroupDelta
+    })
+  }
+
+  dragend (e) {
+    const { onDrop, item } = this.props
+
+    if (onDrop) {
+      onDrop(item, this.state.dragTimeDelta, this.props.order, this.state.dragGroupDelta)
+    }
+
+    this.setState({
+      dragging: false,
+      dragTimeDelta: 0,
+      dragGroupDelta: null
+    })
+  }
+
+  dragTimeDelta (e) {
+    if (!this.state.dragging) {
+      return 0
+    }
+    const deltaX = e.pageX - this.state.dragStartPos.x
+    return deltaX * this.coordinateToTimeRatio()
+  }
+
   dragTime(e) {
     const startTime = this.itemTimeStart
 
     if (this.state.dragging) {
-      const deltaX = e.pageX - this.state.dragStart.x
+      const deltaX = e.pageX - this.state.dragStartPos.x;
       const timeDelta = deltaX * this.coordinateToTimeRatio()
 
       return this.dragTimeSnap(startTime + timeDelta, true)
@@ -154,10 +207,7 @@ export default class Item extends Component {
 
   dragGroupDelta(e) {
     const { groupTops, order, topOffset } = this.props
-    if (this.state.dragging) {
-      if (!this.props.canChangeGroup) {
-        return 0
-      }
+    if (this.state.dragging && this.props.canChangeGroup) {
       let groupDelta = 0
 
       for (var key of Object.keys(groupTops)) {
@@ -170,29 +220,28 @@ export default class Item extends Component {
       }
 
       if (this.props.order + groupDelta < 0) {
-        return 0 - this.props.order
-      } else {
-        return groupDelta
+        groupDelta = 0 - this.props.order;
       }
+
+      return groupDelta;
+
     } else {
       return 0
     }
   }
 
   resizeTimeDelta(e, resizeEdge) {
+    const { dragSnap } = this.props;
     const length = this.itemTimeEnd - this.itemTimeStart
     const timeDelta = this.dragTimeSnap(
       (e.pageX - this.state.resizeStart) * this.coordinateToTimeRatio()
     )
 
-    if (
-      length + (resizeEdge === 'left' ? -timeDelta : timeDelta) <
-      (this.props.dragSnap || 1000)
-    ) {
+    if (length + (resizeEdge === 'left' ? -timeDelta : timeDelta) < (dragSnap || 1000)) {
       if (resizeEdge === 'left') {
-        return length - (this.props.dragSnap || 1000)
+        return length - (dragSnap || 1000);
       } else {
-        return (this.props.dragSnap || 1000) - length
+        return (dragSnap || 1000) - length;
       }
     } else {
       return timeDelta
@@ -220,71 +269,19 @@ export default class Item extends Component {
       .styleCursor(false)
       .on('dragstart', e => {
         if (this.props.selected) {
-          this.setState({
-            dragging: true,
-            dragStart: { x: e.pageX, y: e.pageY },
-            preDragPosition: { x: e.target.offsetLeft, y: e.target.offsetTop },
-            dragTime: this.itemTimeStart,
-            dragGroupDelta: 0
-          })
+          this.dragstart(e);
         } else {
           return false
         }
       })
       .on('dragmove', e => {
         if (this.state.dragging) {
-          let dragTime = this.dragTime(e)
-          let dragGroupDelta = this.dragGroupDelta(e)
-
-          if (this.props.moveResizeValidator) {
-            dragTime = this.props.moveResizeValidator(
-              'move',
-              this.props.item,
-              dragTime
-            )
-          }
-
-          if (this.props.onDrag) {
-            this.props.onDrag(
-              this.itemId,
-              dragTime,
-              this.props.order + dragGroupDelta
-            )
-          }
-
-          this.setState({
-            dragTime: dragTime,
-            dragGroupDelta: dragGroupDelta
-          })
+          this.dragmove(e);
         }
       })
       .on('dragend', e => {
         if (this.state.dragging) {
-          if (this.props.onDrop) {
-            let dragTime = this.dragTime(e)
-
-            if (this.props.moveResizeValidator) {
-              dragTime = this.props.moveResizeValidator(
-                'move',
-                this.props.item,
-                dragTime
-              )
-            }
-
-            this.props.onDrop(
-              this.itemId,
-              dragTime,
-              this.props.order + this.dragGroupDelta(e)
-            )
-          }
-
-          this.setState({
-            dragging: false,
-            dragStart: null,
-            preDragPosition: null,
-            dragTime: null,
-            dragGroupDelta: null
-          })
+          this.dragend(e);
         }
       })
       .on('resizestart', e => {

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -18,7 +18,7 @@ export default class Item extends Component {
 
     dragSnap: PropTypes.number,
     minResizeWidth: PropTypes.number,
-    selected: PropTypes.bool,
+    isSelected: PropTypes.bool,
 
     canChangeGroup: PropTypes.bool.isRequired,
     canMove: PropTypes.bool.isRequired,
@@ -28,7 +28,6 @@ export default class Item extends Component {
     keys: PropTypes.object.isRequired,
     item: PropTypes.object.isRequired,
 
-    onSelect: PropTypes.func,
     onDrag: PropTypes.func,
     onDrop: PropTypes.func,
     onResizing: PropTypes.func,
@@ -37,17 +36,17 @@ export default class Item extends Component {
     itemRenderer: PropTypes.func,
 
     itemProps: PropTypes.object,
-    canSelect: PropTypes.bool,
     topOffset: PropTypes.number,
     dimensions: PropTypes.object,
     groupTops: PropTypes.array,
     useResizeHandle: PropTypes.bool,
     moveResizeValidator: PropTypes.func,
-    onItemDoubleClick: PropTypes.func
+    onItemDoubleClick: PropTypes.func,
+    onItemClick: PropTypes.func
   }
 
   static defaultProps = {
-    selected: false
+    isSelected: false
   }
 
   static contextTypes = {
@@ -83,7 +82,7 @@ export default class Item extends Component {
       nextState.resizeTime !== this.state.resizeTime ||
       nextProps.keys !== this.props.keys ||
       !deepObjectCompare(nextProps.itemProps, this.props.itemProps) ||
-      nextProps.selected !== this.props.selected ||
+      nextProps.isSelected !== this.props.isSelected ||
       nextProps.item !== this.props.item ||
       nextProps.canvasTimeStart !== this.props.canvasTimeStart ||
       nextProps.canvasTimeEnd !== this.props.canvasTimeEnd ||
@@ -92,7 +91,6 @@ export default class Item extends Component {
       nextProps.dragSnap !== this.props.dragSnap ||
       nextProps.minResizeWidth !== this.props.minResizeWidth ||
       nextProps.canChangeGroup !== this.props.canChangeGroup ||
-      nextProps.canSelect !== this.props.canSelect ||
       nextProps.topOffset !== this.props.topOffset ||
       nextProps.canMove !== this.props.canMove ||
       nextProps.canResizeLeft !== this.props.canResizeLeft ||
@@ -261,14 +259,14 @@ export default class Item extends Component {
           bottom: false
         },
         enabled:
-          this.props.selected && (this.canResizeLeft() || this.canResizeRight())
+          this.props.isSelected && (this.canResizeLeft() || this.canResizeRight())
       })
       .draggable({
-        enabled: this.props.selected
+        enabled: this.props.isSelected
       })
       .styleCursor(false)
       .on('dragstart', e => {
-        if (this.props.selected) {
+        if (this.props.isSelected) {
           this.dragstart(e);
         } else {
           return false
@@ -285,7 +283,7 @@ export default class Item extends Component {
         }
       })
       .on('resizestart', e => {
-        if (this.props.selected) {
+        if (this.props.isSelected) {
           this.setState({
             resizing: true,
             resizeEdge: null, // we don't know yet
@@ -396,18 +394,18 @@ export default class Item extends Component {
     this.cacheDataFromProps(nextProps)
 
     let { interactMounted } = this.state
-    const couldDrag = this.props.selected && this.canMove(this.props)
+    const couldDrag = this.props.isSelected && this.canMove(this.props)
     const couldResizeLeft =
-      this.props.selected && this.canResizeLeft(this.props)
+      this.props.isSelected && this.canResizeLeft(this.props)
     const couldResizeRight =
-      this.props.selected && this.canResizeRight(this.props)
-    const willBeAbleToDrag = nextProps.selected && this.canMove(nextProps)
+      this.props.isSelected && this.canResizeRight(this.props)
+    const willBeAbleToDrag = nextProps.isSelected && this.canMove(nextProps)
     const willBeAbleToResizeLeft =
-      nextProps.selected && this.canResizeLeft(nextProps)
+      nextProps.isSelected && this.canResizeLeft(nextProps)
     const willBeAbleToResizeRight =
-      nextProps.selected && this.canResizeRight(nextProps)
+      nextProps.isSelected && this.canResizeRight(nextProps)
 
-    if (nextProps.selected && !interactMounted) {
+    if (nextProps.isSelected && !interactMounted) {
       this.mountInteract()
       interactMounted = true
     }
@@ -479,9 +477,7 @@ export default class Item extends Component {
   }
 
   actualClick(e, clickType) {
-    if (this.props.canSelect && this.props.onSelect) {
-      this.props.onSelect(this.itemId, clickType, e)
-    }
+    this.props.onItemClick && this.props.onItemClick(this.itemId, clickType, e);
   }
 
   renderContent() {
@@ -502,7 +498,7 @@ export default class Item extends Component {
 
     const classNames =
       'rct-item' +
-      (this.props.selected ? ' selected' : '') +
+      (this.props.isSelected ? ' selected' : '') +
       (this.canMove(this.props) ? ' can-move' : '') +
       (this.canResizeLeft(this.props) || this.canResizeRight(this.props)
         ? ' can-resize'

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -30,28 +30,26 @@ export default class Items extends Component {
 
     dragSnap: PropTypes.number,
     minResizeWidth: PropTypes.number,
-    selectedItems: PropTypes.array,
+    selected: PropTypes.array,
 
     canChangeGroup: PropTypes.bool.isRequired,
     canMove: PropTypes.bool.isRequired,
     canResize: PropTypes.oneOf([true, false, 'left', 'right', 'both']),
-    canSelect: PropTypes.bool,
 
     keys: PropTypes.object.isRequired,
 
     moveResizeValidator: PropTypes.func,
-    itemSelect: PropTypes.func,
     itemDragStart: PropTypes.func,
     itemDrag: PropTypes.func,
     itemDrop: PropTypes.func,
     itemResizing: PropTypes.func,
     itemResized: PropTypes.func,
 
+    onItemClick: PropTypes.func,
     onItemDoubleClick: PropTypes.func,
     onItemContextMenu: PropTypes.func,
 
     itemRenderer: PropTypes.func,
-    // selected: PropTypes.array,
 
     dimensionItems: PropTypes.array,
     topOffset: PropTypes.number,
@@ -60,7 +58,7 @@ export default class Items extends Component {
   }
 
   static defaultProps = {
-    // selected: []
+    selected: []
   }
 
   shouldComponentUpdate(nextProps) {
@@ -71,13 +69,12 @@ export default class Items extends Component {
       nextProps.canvasTimeStart === this.props.canvasTimeStart &&
       nextProps.canvasTimeEnd === this.props.canvasTimeEnd &&
       nextProps.canvasWidth === this.props.canvasWidth &&
-      arraysEqual(nextProps.selectedItems, this.props.selectedItems) &&
+      arraysEqual(nextProps.selected, this.props.selected) &&
       nextProps.dragSnap === this.props.dragSnap &&
       nextProps.minResizeWidth === this.props.minResizeWidth &&
       nextProps.canChangeGroup === this.props.canChangeGroup &&
       nextProps.canMove === this.props.canMove &&
       nextProps.canResize === this.props.canResize &&
-      nextProps.canSelect === this.props.canSelect &&
       nextProps.dimensionItems === this.props.dimensionItems &&
       nextProps.topOffset === this.props.topOffset &&
       nextProps.minimumWidthForItemContentVisibility ===
@@ -98,8 +95,9 @@ export default class Items extends Component {
     return groupOrders
   }
 
+  // TODO: move this into the utility function
   isSelected(itemId) {
-    return this.props.selectedItems.indexOf(itemId) > -1;
+    return this.props.selected.indexOf(itemId) > -1;
   }
 
   // TODO: this is exact same logic as utility function
@@ -115,21 +113,18 @@ export default class Items extends Component {
   }
 
   itemDrag = (itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta) => {
-    console.log('itemDrag');
     this.props.itemDrag(itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta)
   }
 
   itemDrop = (itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta) => {
-    console.log('itemDrop');
     const { itemIdKey, itemGroupKey, itemTimeStartKey } = this.props.keys
 
     const groupOrders = getGroupOrders(this.props.groups, this.props.keys)
 
-    this.props.selectedItems.forEach((selectedItemId) => {
+    this.props.selected.forEach((selectedItemId) => {
       const item = this.props.items.find(itemObj => _get(itemObj, itemIdKey) === selectedItemId)
       let order = groupOrders[_get(item, itemGroupKey)]
 
-      console.log('items itemDrop')
       this.props.itemDrop(
         selectedItemId,
         _get(item, itemTimeStartKey) + dragTimeDelta,
@@ -168,7 +163,7 @@ export default class Items extends Component {
           .filter(item => sortedDimensionItems[_get(item, itemIdKey)])
           .map(item => {
             const itemId = _get(item, itemIdKey);
-            const selected = this.isSelected(itemId);
+            //const selected = this.isSelected(itemId);
 
             return <Item
               key={itemId}
@@ -178,7 +173,7 @@ export default class Items extends Component {
               dimensions={
                 sortedDimensionItems[_get(item, itemIdKey)].dimensions
               }
-              selected={selected}
+              isSelected={this.isSelected(itemId)}
               canChangeGroup={
                 _get(item, 'canChangeGroup') !== undefined
                   ? _get(item, 'canChangeGroup')
@@ -191,11 +186,6 @@ export default class Items extends Component {
               }
               canResizeLeft={canResizeLeft(item, this.props.canResize)}
               canResizeRight={canResizeRight(item, this.props.canResize)}
-              canSelect={
-                _get(item, 'canSelect') !== undefined
-                  ? _get(item, 'canSelect')
-                  : this.props.canSelect
-              }
               useResizeHandle={this.props.useResizeHandle}
               topOffset={this.props.topOffset}
               groupTops={this.props.groupTops}
@@ -212,7 +202,7 @@ export default class Items extends Component {
               onDrop={this.props.itemDrop}
               onItemDoubleClick={this.props.onItemDoubleClick}
               onContextMenu={this.props.onItemContextMenu}
-              onSelect={this.props.itemSelect}
+              onItemClick={this.props.onItemClick}
               itemRenderer={this.props.itemRenderer}
               minimumWidthForItemContentVisibility={
                 minimumWidthForItemContentVisibility

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -112,34 +112,6 @@ export default class Items extends Component {
     })
   }
 
-  itemDrag = (itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta) => {
-    this.props.itemDrag(itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta)
-  }
-
-  itemDrop = (itemId, dragTimeDelta, oldGroupOrder, dragGroupDelta) => {
-    const { itemIdKey, itemGroupKey, itemTimeStartKey } = this.props.keys
-
-    const groupOrders = getGroupOrders(this.props.groups, this.props.keys)
-
-    this.props.selected.forEach((selectedItemId) => {
-      const item = this.props.items.find(itemObj => _get(itemObj, itemIdKey) === selectedItemId)
-      let order = groupOrders[_get(item, itemGroupKey)]
-
-      this.props.itemDrop(
-        selectedItemId,
-        _get(item, itemTimeStartKey) + dragTimeDelta,
-        order,
-        dragGroupDelta
-      )
-    })
-
-    this.setState({
-      isDraggingItem: false,
-      dragTimeDelta: 0,
-      infoLabel: null
-    })
-  }
-
   render() {
     const {
       canvasTimeStart,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ const config = {
     demo: isProd
       ? ['./index.js']
       : [
-          `webpack-dev-server/client?http://0.0.0.0:${port}`,
+          `webpack-dev-server/client?http://localhost:${port}`,
           'webpack/hot/only-dev-server',
           './index.js'
         ]


### PR DESCRIPTION
This is a fork of the previous 2 multi-select pull requests but refactored to work with the 0.16.x branch. 

It's not completely ready to merge yet but i'm opening it now for comments and advice. 

- onItemMove now returns a relative unix time to the initial item start time. Would like some advice on whether this is for better or worse as it means it will definitely be a breaking change. 
- canSelect by default enables multi select mode. I was thinking of keeping canSelect as a boolean to allow for turning it off and on and introducing a new prop, multiSelect, (defaulted to false) so that current behaviour of single select is retained by default.

Depending on the above, I will need to update the demos before this can be merged.


- [ ] ~introduce selectMode enum, single, multi, disabled~

- [x] remove canSelect

- [ ] update readme with breaking changes

- [ ] update changelog

- [ ] potential refactor of handleItemMove callback 

- [x] update all demos to work with new changes

- [ ] investigate canSelect override in item props and what changes (if any) need to occur