### PR TITLE
Move interactjs to peerDependency, up version to fix #297

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### Breaking
+
+* `interactjs` is a peerDependency (wasn't previously). Upped version to 1.3.4 to fix issue #297
+
 ### Fixed
 
 * fix for issue where NaN is returned in onItemMove if the startTime is not unix timestamp #300

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn add react-calendar-timeline
 npm install --save react-calendar-timeline
 ```
 
-`react-calendar-timeline` has `react`, `react-dom`, [`moment`](http://momentjs.com/) and [`interact.js`](http://interactjs.io/docs/) as peer dependencies.
+`react-calendar-timeline` has `react`, `react-dom`, [`moment`](http://momentjs.com/) and [`interactjs`](http://interactjs.io/docs/) as peer dependencies.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
   },
   "dependencies": {
     "element-resize-detector": "^1.1.12",
-    "interact.js": "^1.2.6",
     "lodash.isequal": "^4.5.0"
   },
   "peerDependencies": {
     "moment": "*",
+    "interactjs": "^1.3.4",
     "react": "^0.14.8 || >=15"
   },
   "devDependencies": {
@@ -107,6 +107,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "faker": "^4.1.0",
     "file-loader": "^0.11.2",
+    "interactjs": "^1.3.4",
     "jest": "^22.0.6",
     "jsdom": "^11.5.1",
     "moment": "^2.11.1",

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import interact from 'interact.js'
+import interact from 'interactjs'
 import moment from 'moment'
 
 import { _get, deepObjectCompare } from '../utility/generic'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ const config = {
   devtool: isProd ? 'hidden-source-map' : 'cheap-eval-source-map',
   context: path.join(__dirname, './demo'),
   entry: {
-    vendor: ['react', 'react-dom', 'faker', 'interact.js', 'moment'],
+    vendor: ['react', 'react-dom', 'faker', 'interactjs', 'moment'],
     demo: isProd
       ? ['./index.js']
       : [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,9 +2773,9 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-interact.js@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/interact.js/-/interact.js-1.2.8.tgz#b62bc004563b5c6f294b6b115b396205d843f60b"
+interactjs@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/interactjs/-/interactjs-1.3.4.tgz#9d5aa886f8fa03ea2f6c711e688792e3d3bde1ff"
 
 interpret@^0.6.4:
   version "0.6.6"


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/297

**Overview of PR**

* Move interactjs to peerDependency (breaking change)
