### PR TITLE
Pass Canvas time values in timelineContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### Added
+
+* pass canvasTimeStart/End via timelineContext to the itemRenderer prop
+
 ### 0.17.0
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### 0.17.0
+
 ### Breaking
 
 * throw more descriptive error if visibleTimeStart/End and defaultTimeStart/End are not passed as props. Timeline no longer calculates visibleTime start and end from items. Removed `onTimeInit` prop as it no longer serves a purpose. - #299

--- a/README.md
+++ b/README.md
@@ -458,8 +458,10 @@ This component will also be passed a `timelineContext` object:
 
 ```typescript
 {
-  visibleTimeStart: number, // denotes the start time in ms of the timeline
-  visibleTimeEnd: number, // denotes the end time in ms of the timeline
+  visibleTimeStart: number, // denotes the start time in ms of the visible timeline
+  visibleTimeEnd: number, // denotes the end time in ms of the visible timeline
+  canvasTimeStart: number, // denotes the start time in ms of the canvas timeline
+  canvasTimeEnd: number, // denotes the end time in ms of the canvas timeline
   timelineWidth: number, // denotes the width in pixels of the timeline
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -251,7 +251,14 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   getTimelineContext = () => {
-    const { width, visibleTimeStart, visibleTimeEnd } = this.state
+    const {
+      width,
+      visibleTimeStart,
+      visibleTimeEnd,
+      canvasTimeStart
+    } = this.state
+    const zoom = visibleTimeEnd - visibleTimeStart
+    const canvasTimeEnd = canvasTimeStart + zoom * 3
 
     //TODO: Performance
     //prob wanna memoize this so we ensure that if no items changed,
@@ -259,7 +266,9 @@ export default class ReactCalendarTimeline extends Component {
     return {
       timelineWidth: width,
       visibleTimeStart,
-      visibleTimeEnd
+      visibleTimeEnd,
+      canvasTimeStart,
+      canvasTimeEnd
     }
   }
 


### PR DESCRIPTION
Currently, only visibleTimeStart/End and canvas width are being passed to the timelineContext prop in itemRenderer. Let's pass canvas times too.