### PR TITLE
Support Item prop style. Provide prop selected to itemRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### Added
+
+* support `Item` prop `style`
+* `selected` is provided to `itemRenderer`
+
 ### 0.17,1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### 0.17,1
+
+### Added
+
+* pass canvasTimeStart/End via timelineContext to the itemRenderer prop
+
 ### 0.17.0
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Expects either a vanilla JS array or an immutableJS array, consisting of objects
   canResize: false,
   canChangeGroup: false,
   className: 'weekend',
+  style: {
+    backgroundColor: 'fuchsia'
+  },
   itemProps: {
     // these optional attributes are passed to the root <div /> of each item as <div {...itemProps} />
     'data-custom-attribute': 'Random content',
@@ -429,7 +432,7 @@ Called when the bounds in the calendar's canvas change. Use it for example to lo
 ### itemRenderer
 
 React component that will be used to render the item content. Will be
-passed the `item` as a prop.
+passed the `item` and the `selected` as a props.
 
 Using complex components may result in performance problems.
 
@@ -444,11 +447,11 @@ let items = [
   }
 ]
 
-itemRenderer = ({ item }) => {
+itemRenderer = ({ item, selected }) => {
   return (
     <div className='custom-item'>
       <span className='title'>{item.title}</span>
-      <p className='tip'>{item.tip}</p>
+      {selected && <p className='tip'>{item.tip}</p>}
     </div>
   )
 }

--- a/README.md
+++ b/README.md
@@ -458,8 +458,10 @@ This component will also be passed a `timelineContext` object:
 
 ```typescript
 {
-  visibleTimeStart: number, // denotes the start time in ms of the timeline
-  visibleTimeEnd: number, // denotes the end time in ms of the timeline
+  visibleTimeStart: number, // denotes the start time in ms of the visible timeline
+  visibleTimeEnd: number, // denotes the end time in ms of the visible timeline
+  canvasTimeStart: number, // denotes the start time in ms of the canvas timeline
+  canvasTimeEnd: number, // denotes the end time in ms of the canvas timeline
   timelineWidth: number, // denotes the width in pixels of the timeline
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -251,7 +251,14 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   getTimelineContext = () => {
-    const { width, visibleTimeStart, visibleTimeEnd } = this.state
+    const {
+      width,
+      visibleTimeStart,
+      visibleTimeEnd,
+      canvasTimeStart
+    } = this.state
+    const zoom = visibleTimeEnd - visibleTimeStart
+    const canvasTimeEnd = canvasTimeStart + zoom * 3
 
     //TODO: Performance
     //prob wanna memoize this so we ensure that if no items changed,
@@ -259,7 +266,9 @@ export default class ReactCalendarTimeline extends Component {
     return {
       timelineWidth: width,
       visibleTimeStart,
-      visibleTimeEnd
+      visibleTimeEnd,
+      canvasTimeStart,
+      canvasTimeEnd
     }
   }
 

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -519,12 +519,12 @@ export default class Item extends Component {
       (this.props.item.className ? ` ${this.props.item.className}` : '')
 
     const style = {
+      ...this.props.item.style,
       left: `${dimensions.left}px`,
       top: `${dimensions.top}px`,
       width: `${dimensions.width}px`,
       height: `${dimensions.height}px`,
-      lineHeight: `${dimensions.height}px`,
-      ...this.props.item.style
+      lineHeight: `${dimensions.height}px`
     }
 
     const showInnerContents =

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -491,7 +491,11 @@ export default class Item extends Component {
     const timelineContext = this.context.getTimelineContext()
     const Comp = this.props.itemRenderer
     if (Comp) {
-      return <Comp item={this.props.item} timelineContext={timelineContext} />
+      return <Comp
+        item={this.props.item}
+        selected={this.props.selected}
+        timelineContext={timelineContext}
+      />
     } else {
       return this.itemTitle
     }
@@ -519,7 +523,8 @@ export default class Item extends Component {
       top: `${dimensions.top}px`,
       width: `${dimensions.width}px`,
       height: `${dimensions.height}px`,
-      lineHeight: `${dimensions.height}px`
+      lineHeight: `${dimensions.height}px`,
+      ...this.props.item.style
     }
 
     const showInnerContents =


### PR DESCRIPTION
**Issue Number**

Without issue

**Overview of PR**

Allow to specify custom style for the item element. For example, it can be a different background color for each item (driven by some business logic, etc). Strange that it wasn't implemented before. it is so useful feature.

As well as, provide prop `selected` to the itemRenderer. I have a few cases when I need to know inside the item content does it selected or no. For example, I prefer to render some advanced information inside selected items. Or some way react to this prop in the child component lifecycle - open a modal, or send a request at last.
