### PR TITLE
onHeaderClick and onSubHeader click callbacks (#140)

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -82,6 +82,8 @@ export default class ReactCalendarTimeline extends Component {
     onCanvasMouseLeave: PropTypes.func,
     onCanvasMouseMove: PropTypes.func,
     onZoom: PropTypes.func,
+    onHeaderClick: PropTypes.func,
+    onSubHeaderClick: PropTypes.func,
 
     moveResizeValidator: PropTypes.func,
 
@@ -952,6 +954,8 @@ export default class ReactCalendarTimeline extends Component {
         leftSidebarHeader={leftSidebar}
         rightSidebarHeader={rightSidebar}
         headerRef={this.props.headerRef}
+        onHeaderClick={this.props.onHeaderClick}
+        onSubHeaderClick={this.props.onSubHeaderClick}
       />
     )
   }

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -21,7 +21,10 @@ class Header extends Component {
     registerScroll: PropTypes.func.isRequired,
     leftSidebarHeader: PropTypes.node,
     rightSidebarHeader: PropTypes.node,
-    headerRef: PropTypes.func.isRequired
+    headerRef: PropTypes.func.isRequired,
+
+    onHeaderClick: PropTypes.func,
+    onSubHeaderClick: PropTypes.func,
   }
 
   render() {

--- a/src/lib/layout/TimelineElementsHeader.js
+++ b/src/lib/layout/TimelineElementsHeader.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import moment from 'moment'
 
-import { iterateTimes, getNextUnit } from '../utility/calendar'
+import { iterateTimes, getNextUnit, getPreviousUnit } from '../utility/calendar'
 
 export default class TimelineElementsHeader extends Component {
   static propTypes = {
@@ -18,7 +18,10 @@ export default class TimelineElementsHeader extends Component {
     subHeaderLabelFormats: PropTypes.object.isRequired,
     headerLabelGroupHeight: PropTypes.number.isRequired,
     headerLabelHeight: PropTypes.number.isRequired,
-    registerScroll: PropTypes.func.isRequired
+    registerScroll: PropTypes.func.isRequired,
+
+    onHeaderClick: PropTypes.func,
+    onSubHeaderClick: PropTypes.func,
   }
 
   constructor(props) {
@@ -147,13 +150,15 @@ export default class TimelineElementsHeader extends Component {
           // have label content fill the entire width
           const contentWidth = Math.min(labelWidth, canvasWidth / 3)
 
+          let defaultOnClick = () => this.handlePeriodClick(time, nextUnit);
+
           topHeaderLabels.push(
             <div
               key={`top-label-${time.valueOf()}`}
               className={`rct-label-group${
                 hasRightSidebar ? ' rct-has-right-sidebar' : ''
               }`}
-              onClick={() => this.handlePeriodClick(time, nextUnit)}
+              onClick={(e) => this.props.onHeaderClick ? this.props.onHeaderClick(time, minUnit, nextUnit, e, defaultOnClick) : defaultOnClick()}
               style={{
                 left: `${left - 1}px`,
                 width: `${labelWidth}px`,
@@ -172,6 +177,7 @@ export default class TimelineElementsHeader extends Component {
     }
 
     const bottomHeaderLabels = []
+    const previousUnit = getPreviousUnit(minUnit);
     iterateTimes(
       canvasTimeStart,
       canvasTimeEnd,
@@ -186,13 +192,15 @@ export default class TimelineElementsHeader extends Component {
         )
         const leftCorrect = firstOfType ? 1 : 0
 
+        let defaultOnClick = () => this.handlePeriodClick(time, minUnit);
+
         bottomHeaderLabels.push(
           <div
             key={`label-${time.valueOf()}`}
             className={`rct-label ${twoHeaders ? '' : 'rct-label-only'} ${
               firstOfType ? 'rct-first-of-type' : ''
             } ${minUnit !== 'month' ? `rct-day-${time.day()}` : ''} `}
-            onClick={() => this.handlePeriodClick(time, minUnit)}
+            onClick={(e) => this.props.onSubHeaderClick ? this.props.onSubHeaderClick(time, minUnit, previousUnit, e, defaultOnClick) : defaultOnClick()}
             style={{
               left: `${left - leftCorrect}px`,
               width: `${labelWidth}px`,

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -116,6 +116,18 @@ export function getNextUnit(unit) {
   return nextUnits[unit] || ''
 }
 
+export function getPreviousUnit(unit) {
+  let previousUnits = {
+    minute: 'second',
+    hour: 'minute',
+    day: 'hour',
+    month: 'day',
+    year: 'month'
+  }
+
+  return previousUnits[unit] || ''
+}
+
 export function calculateDimensions({
   itemTimeStart,
   itemTimeEnd,


### PR DESCRIPTION
**Issue Number**
https://github.com/namespace-ee/react-calendar-timeline/issues/140

**Overview of PR**
Added two callbacks for when the headers are clicked, if they exist use them if not use the default onClick. 
Signatures: 
onSubHeaderClick(time, previousUnit, nextUnit, event, defaultOnClick)
onHeaderClick(time, previousUnit, nextUnit, event, defaultOnClick)

Passing the defaultOnClick in case the user wants to do some logic before moving on to the default behavior.