### PR TITLE
fixing the import of interactjs (#352)

### DIFF
--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import interact from 'interactjs'
+import interact from 'interactjs/src/index';
 import moment from 'moment'
 
 import { _get, deepObjectCompare } from '../utility/generic'


### PR DESCRIPTION
**Issue Number**
#352 

**Overview of PR**
I wasn't able to really test this except I know from messing around in my own separate project, that making this changes fixes the problem. 
I'm not sure why, I think the issue is my project uses browserify and this one is using webpack (maybe webpack knows how to handle this). But yarn start works fine.