### PR TITLE
Simplify calculate-dimensions/bound item width and left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 * support passing `style` prop from item - #347
 * `selected` is provided to `itemRenderer` - #348
+* simplify logic for calculate dimensions and prevent item width and left properties from being unbounded - (refactoring)
 
 ### 0.17,1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ### Added
 
-* support `Item` prop `style`
-* `selected` is provided to `itemRenderer`
+* support passing `style` prop from item - #347
+* `selected` is provided to `itemRenderer` - #348
 
 ### 0.17,1
 

--- a/__tests__/utils/calendar/calculate-dimensions.js
+++ b/__tests__/utils/calendar/calculate-dimensions.js
@@ -23,7 +23,6 @@ describe('calculateDimensions', () => {
       collisionLeft: 200,
       collisionWidth: 100,
       left: 200,
-      originalLeft: 200,
       width: 100
     })
   })
@@ -48,14 +47,13 @@ describe('calculateDimensions', () => {
 
     expect(dimension).toMatchObject({
       collisionLeft: 192,
-      collisionWidth: 108,
+      collisionWidth: 100,
       left: 192,
-      originalLeft: 200,
       width: 100
     })
   })
 
-  it('the item is on the left side clipped', () => {
+  it('items timeStart is less than canvasTimeStart', () => {
     let example = {
       itemTimeStart: 0,
       itemTimeEnd: 300,
@@ -76,40 +74,63 @@ describe('calculateDimensions', () => {
     expect(calculateDimensions(example)).toMatchObject({
       collisionLeft: 0,
       collisionWidth: 300,
-      left: -100,
-      originalLeft: 0,
-      width: 300
+      left: 0,
+      width: 200
     })
   })
 
-  it('the item is on the right side clipped', () => {
+  it('items timeEnd is greater than canvasTimeEnd', () => {
     let example = {
-      itemTimeStart: 700,
-      itemTimeEnd: 1000,
+      itemTimeStart: 400,
+      itemTimeEnd: 700,
       isDragging: false,
       isResizing: false,
-      canvasTimeStart: 500,
-      canvasTimeEnd: 900,
+      canvasTimeStart: 100,
+      canvasTimeEnd: 500,
       canvasWidth: 400,
       dragSnap: 0,
       dragTime: false, // we are not draging right now
       resizingItem: false,
       resizingEdge: false,
       resizeTime: false, // we are not resizing right now
-      visibleTimeStart: 500,
-      visibleTimeEnd: 900
+      visibleTimeStart: 100,
+      visibleTimeEnd: 500
     }
 
     expect(calculateDimensions(example)).toMatchObject({
-      collisionLeft: 700,
+      collisionLeft: 400,
       collisionWidth: 300,
-      left: 200,
-      originalLeft: 700,
-      width: 300
+      left: 300,
+      width: 100
+    })
+  })
+  it('item time range completely overlaps canvas time range', () => {
+    let example = {
+      itemTimeStart: 0, // item range extends before and after canvas
+      itemTimeEnd: 600,
+      isDragging: false,
+      isResizing: false,
+      canvasTimeStart: 100,
+      canvasTimeEnd: 500,
+      canvasWidth: 400,
+      dragSnap: 0,
+      dragTime: false, // we are not draging right now
+      resizingItem: false,
+      resizingEdge: false,
+      resizeTime: false, // we are not resizing right now
+      visibleTimeStart: 100,
+      visibleTimeEnd: 500
+    }
+
+    expect(calculateDimensions(example)).toMatchObject({
+      collisionLeft: 0,
+      collisionWidth: 600,
+      left: 0,
+      width: 400
     })
   })
 
-  it('the item is draged', () => {
+  it('the item is dragged', () => {
     const dimension = calculateDimensions({
       itemTimeStart: 200,
       itemTimeEnd: 300,
@@ -128,10 +149,9 @@ describe('calculateDimensions', () => {
     })
 
     expect(dimension).toMatchObject({
-      collisionLeft: 200,
-      collisionWidth: 200,
+      collisionLeft: 300,
+      collisionWidth: 100,
       left: 300,
-      originalLeft: 200,
       width: 100
     })
   })
@@ -156,7 +176,6 @@ describe('calculateDimensions', () => {
       collisionLeft: 200,
       collisionWidth: 50,
       left: 200,
-      originalLeft: 200,
       width: 50
     })
   })
@@ -183,7 +202,6 @@ describe('calculateDimensions', () => {
       collisionLeft: 210,
       collisionWidth: 90,
       left: 210,
-      originalLeft: 200,
       width: 90
     })
   })

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1028,7 +1028,6 @@ export default class ReactCalendarTimeline extends Component {
 
     const {
       keys,
-      dragSnap,
       lineHeight,
       headerLabelGroupHeight,
       headerLabelHeight,
@@ -1069,7 +1068,6 @@ export default class ReactCalendarTimeline extends Component {
         canvasTimeStart,
         canvasTimeEnd,
         canvasWidth,
-        dragSnap,
         dragTime,
         resizingEdge,
         resizeTime

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -124,7 +124,6 @@ export function calculateDimensions({
   canvasTimeStart,
   canvasTimeEnd,
   canvasWidth,
-  dragSnap,
   dragTime,
   resizingEdge,
   resizeTime
@@ -134,31 +133,18 @@ export function calculateDimensions({
   const itemEnd =
     isResizing && resizingEdge === 'right' ? resizeTime : itemTimeEnd
 
-  let x = isDragging ? dragTime : itemStart
+  const itemTimeRange = itemEnd - itemStart
 
-  let w = Math.max(itemEnd - itemStart, dragSnap)
-
-  let collisionX = itemStart
-  let collisionW = w
-
-  if (isDragging) {
-    if (itemTimeStart >= dragTime) {
-      collisionX = dragTime
-      collisionW = Math.max(itemTimeEnd - dragTime, dragSnap)
-    } else {
-      collisionW = Math.max(dragTime - itemTimeStart + w, dragSnap)
-    }
-  }
+  let newItemStart = isDragging ? dragTime : itemStart
 
   const ratio =
     1 / coordinateToTimeRatio(canvasTimeStart, canvasTimeEnd, canvasWidth)
 
   const dimensions = {
-    left: (x - canvasTimeStart) * ratio,
-    width: Math.max(w * ratio, 3),
-    collisionLeft: collisionX,
-    originalLeft: itemTimeStart,
-    collisionWidth: collisionW
+    left: (newItemStart - canvasTimeStart) * ratio,
+    width: Math.max(itemTimeRange * ratio, 3),
+    collisionLeft: newItemStart,
+    collisionWidth: itemTimeRange
   }
 
   return dimensions

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -140,9 +140,14 @@ export function calculateDimensions({
   const ratio =
     1 / coordinateToTimeRatio(canvasTimeStart, canvasTimeEnd, canvasWidth)
 
+  // restrict startTime and endTime to be bounded by canvasTimeStart and canasTimeEnd
+  const effectiveStartTime = Math.max(itemStart, canvasTimeStart)
+  const effectiveEndTime = Math.min(itemEnd, canvasTimeEnd)
+  const itemWidth = (effectiveEndTime - effectiveStartTime) * ratio
+
   const dimensions = {
-    left: (newItemStart - canvasTimeStart) * ratio,
-    width: Math.max(itemTimeRange * ratio, 3),
+    left: Math.max(newItemStart - canvasTimeStart, 0) * ratio,
+    width: Math.max(itemWidth, 3),
     collisionLeft: newItemStart,
     collisionWidth: itemTimeRange
   }


### PR DESCRIPTION
**Issue Number**

None.
**Overview of PR**

 This is a refactoring of calculate dimensions to simplify the logic. These changes also bound the width of an item to the width of the canvas and set a floor on the left value of an item.

These changes might also fix https://github.com/namespace-ee/react-calendar-timeline/issues/292
