### PR TITLE
Bringing sensible `scroll-behavior` value to prevent aberrant behavio…

### DIFF
--- a/src/lib/Timeline.scss
+++ b/src/lib/Timeline.scss
@@ -23,6 +23,7 @@ $weekend: rgba(250, 246, 225, 0.5);
 .react-calendar-timeline {
   * {
     box-sizing: border-box;
+    scroll-behavior: unset;
   }
 
   .rct-outer {


### PR DESCRIPTION
This is self explanatory. When `scroll-behavior` is set to a different then 'initial' value, the timeline behaves in erratic fashion. To reproduce set the default scolling behaviour of all element to `smooth` and you will see the timeline missbehaving badly.

Setting this value explicitly to `unset` (rather than `inital`) is more sensible and creates a safe default.