### PR TITLE
332 vertical scroll in fixed div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres (more or less) to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* Added optional verticalScrollContainer prop, can be used when the Timeline is inside a fixed element in order to support vertical scroll
 
 ### 0.18.1
 

--- a/README.md
+++ b/README.md
@@ -731,6 +731,30 @@ render() {
 }
 ```
 
+## The timeline can't scroll vertically inside a fixed div
+By default the timeline uses the window properties in order to scroll vertically.
+If inside a fixed element the window might not be able to scroll because the height of the fixed element does not impact the  window height.
+In order to solve that, provide the element ref of the containing fixed element.
+
+```jsx
+constructor(props) {
+    super(props)
+    // Create the ref
+    this.scrollContainerRef = React.createRef();
+}
+
+render () {
+  // Assign the created ref to the containing element
+  // Make sure the element has a height and overflow auto or scroll
+  // Then provide the created ref to the verticalScrollContainer property
+  <div style={{position:'fixed', height: 600, overflow:'scroll'}} ref={this.scrollContainerRef}>
+    <Timeline
+      verticalScrollContainer={this.scrollContainerRef}>
+    </Timeline>
+  </div>
+}
+```
+
 ## I'm using Babel with Rollup or Webpack 2+ and I'm getting strange bugs with click events
 
 These module bundlers don't use the transpiled (ES5) code of this module. They load the original ES2015+ source. Thus your babel configuration needs to match ours. We recommend adding the [`stage-0` preset](https://babeljs.io/docs/plugins/preset-stage-0/) to your `.babelrc` to make sure everything works as intended.

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -87,6 +87,8 @@ export default class ReactCalendarTimeline extends Component {
 
     style: PropTypes.object,
 
+    verticalScrollContainer: PropTypes.object,
+
     keys: PropTypes.shape({
       groupIdKey: PropTypes.string,
       groupTitleKey: PropTypes.string,
@@ -1198,6 +1200,7 @@ export default class ReactCalendarTimeline extends Component {
                 onMouseLeave={this.handleScrollMouseLeave}
                 onMouseMove={this.handleScrollMouseMove}
                 onContextMenu={this.handleScrollContextMenu}
+                verticalScrollContainer={this.props.verticalScrollContainer && this.props.verticalScrollContainer.current}
               >
                 <div
                   ref={el => (this.canvasComponent = el)}

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -318,6 +318,13 @@ export default class ReactCalendarTimeline extends Component {
     this.state.groupTops = groupTops
 
     /* eslint-enable */
+
+    // Wrap the scroll container in our helper, because we might not have a container and want to use the window. which sometimes has different props\methods.
+    this.scrollContainerHelper = {
+      getYOffset: () => this.props.verticalScrollContainer && this.props.verticalScrollContainer.current ? this.props.verticalScrollContainer.current.scrollTop : window.pageYOffset,
+      getXOffset: () => this.props.verticalScrollContainer && this.props.verticalScrollContainer.current ? this.props.verticalScrollContainer.current.scrollLeft : window.pageYOffset,
+      scrollTo: (x, y) => this.props.verticalScrollContainer && this.props.verticalScrollContainer.current ? this.props.verticalScrollContainer.current.scrollTo(x, y) : window.scrollTo(x, y)
+    }
   }
 
   componentDidMount() {
@@ -1200,7 +1207,7 @@ export default class ReactCalendarTimeline extends Component {
                 onMouseLeave={this.handleScrollMouseLeave}
                 onMouseMove={this.handleScrollMouseMove}
                 onContextMenu={this.handleScrollContextMenu}
-                verticalScrollContainer={this.props.verticalScrollContainer && this.props.verticalScrollContainer.current}
+                scrollContainerHelper={this.scrollContainerHelper}
               >
                 <div
                   ref={el => (this.canvasComponent = el)}

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -16,7 +16,9 @@ class ScrollElement extends Component {
     onContextMenu: PropTypes.func.isRequired,
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
-    onScroll: PropTypes.func.isRequired
+    onScroll: PropTypes.func.isRequired,
+
+    verticalScrollContainer: PropTypes.object,
   }
 
   constructor() {
@@ -75,7 +77,8 @@ class ScrollElement extends Component {
         }
       }
       if (e.deltaY !== 0) {
-        window.scrollTo(window.pageXOffset, window.pageYOffset + e.deltaY)
+        this.verticallyScrollTo(null, e.deltaY)
+
         if (traditionalZoom) {
           const parentPosition = getParentPosition(e.currentTarget)
           const xPosition = e.clientX - parentPosition.x
@@ -139,8 +142,10 @@ class ScrollElement extends Component {
       let y = e.touches[0].clientY
 
       this.lastTouchDistance = null
-      this.singleTouchStart = { x: x, y: y, screenY: window.pageYOffset }
-      this.lastSingleTouch = { x: x, y: y, screenY: window.pageYOffset }
+      // Cache the position of the top of the vertical scroll container while the user scrolls
+      let screenY = this.props.verticalScrollContainer ? this.props.verticalScrollContainer.scrollTop : window.pageYOffset;
+      this.singleTouchStart = { x: x, y: y, screenY: screenY }
+      this.lastSingleTouch = { x: x, y: y, screenY: screenY }
     }
   }
 
@@ -174,10 +179,7 @@ class ScrollElement extends Component {
         this.scrollComponent.scrollLeft -= deltaX
       }
       if (moveY) {
-        window.scrollTo(
-          window.pageXOffset,
-          this.singleTouchStart.screenY - deltaY0
-        )
+        this.verticallyScrollTo(this.singleTouchStart.screenY, -deltaY0);
       }
     }
   }
@@ -189,6 +191,20 @@ class ScrollElement extends Component {
     if (this.lastSingleTouch) {
       this.lastSingleTouch = null
       this.singleTouchStart = null
+    }
+  }
+
+  verticallyScrollTo(startY, deltaY) {
+    // If no startY given get the default, however accept 0 as a valid startY
+    if (!startY && startY !== 0) {
+      startY = this.props.verticalScrollContainer ? this.props.verticalScrollContainer.scrollTop : window.pageYOffset;
+    }
+
+    // Decide on what element to scroll
+    if (this.props.verticalScrollContainer) {
+      this.props.verticalScrollContainer.scrollTo(this.props.verticalScrollContainer.scrollLeft, startY + deltaY)
+    } else {
+      window.scrollTo(window.pageXOffset, startY + deltaY)
     }
   }
 

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -9,6 +9,7 @@ class ScrollElement extends Component {
     height: PropTypes.number.isRequired,
     traditionalZoom: PropTypes.bool.isRequired,
     scrollRef: PropTypes.func.isRequired,
+    scrollContainerHelper: PropTypes.object.isRequired,
     isInteractingWithItem: PropTypes.bool.isRequired,
     // onMouseEnter: PropTypes.func.isRequired,
     // onMouseMove: PropTypes.func.isRequired,
@@ -17,8 +18,6 @@ class ScrollElement extends Component {
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
     onScroll: PropTypes.func.isRequired,
-
-    verticalScrollContainer: PropTypes.object,
   }
 
   constructor() {
@@ -143,7 +142,7 @@ class ScrollElement extends Component {
 
       this.lastTouchDistance = null
       // Cache the position of the top of the vertical scroll container while the user scrolls
-      let screenY = this.props.verticalScrollContainer ? this.props.verticalScrollContainer.scrollTop : window.pageYOffset;
+      let screenY = this.props.scrollContainerHelper.getYOffset();
       this.singleTouchStart = { x: x, y: y, screenY: screenY }
       this.lastSingleTouch = { x: x, y: y, screenY: screenY }
     }
@@ -197,15 +196,9 @@ class ScrollElement extends Component {
   verticallyScrollTo(startY, deltaY) {
     // If no startY given get the default, however accept 0 as a valid startY
     if (!startY && startY !== 0) {
-      startY = this.props.verticalScrollContainer ? this.props.verticalScrollContainer.scrollTop : window.pageYOffset;
+      startY = this.props.scrollContainerHelper.getYOffset();;
     }
-
-    // Decide on what element to scroll
-    if (this.props.verticalScrollContainer) {
-      this.props.verticalScrollContainer.scrollTo(this.props.verticalScrollContainer.scrollLeft, startY + deltaY)
-    } else {
-      window.scrollTo(window.pageXOffset, startY + deltaY)
-    }
+    this.props.scrollContainerHelper.scrollTo(this.props.scrollContainerHelper.getXOffset(), startY + deltaY);
   }
 
   render() {


### PR DESCRIPTION
**Issue Number**
https://github.com/namespace-ee/react-calendar-timeline/issues/332

**Overview of PR**
Added a property called verticalScrollContainer, if provided referring to that when wanting to scroll or calculate the scrollTop. If not provided falling back to the window element (like we have today)