### PR TITLE
remove white space after row class name

### DIFF
--- a/src/lib/row/GroupRow.js
+++ b/src/lib/row/GroupRow.js
@@ -36,7 +36,7 @@ class GroupRow extends Component {
         <div
           onContextMenu={onContextMenu}
           onDoubleClick={onDoubleClick}
-          className={(isEvenRow ? 'rct-hl-even ' : 'rct-hl-odd ') + (classNamesForGroup ? classNamesForGroup.join(' ') : '')}
+          className={((isEvenRow ? 'rct-hl-even ' : 'rct-hl-odd ') + (classNamesForGroup ? classNamesForGroup.join(' ') : '')).trim()}
           style={style}
         />
       </PreventClickOnDrag>


### PR DESCRIPTION
**Issue Number**

RCT row class names have an white space at the end.

**Overview of PR**

Remove the class name white space by using method trim().

_Don't forget to update the CHANGELOG.md file with any changes that are in this PR_
