### PR TITLE
Added group label key to fix label info onDrag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+### Fixed
+
+* Provided a new key `groupLabelKey` to allow splitting of the key used to render the Sidebar and the InfoLabel visible during drag operations. `groupTitleKey` continues to be used to render the Sidebar.
+
 ### 0.20.0
 
 ### improvements

--- a/demo/app/demo-tree-groups/index.js
+++ b/demo/app/demo-tree-groups/index.js
@@ -9,6 +9,7 @@ var keys = {
   groupIdKey: 'id',
   groupTitleKey: 'title',
   groupRightTitleKey: 'rightTitle',
+  groupLabelKey: 'label',
   itemIdKey: 'id',
   itemTitleKey: 'title',
   itemDivTitleKey: 'title',
@@ -105,7 +106,7 @@ export default class App extends Component {
         sidebarContent={<div>Above The Left</div>}
         rightSidebarWidth={150}
         rightSidebarContent={<div>Above The Right</div>}
-        canMove
+        canMove={true}
         canResize="right"
         canSelect
         itemsSorted

--- a/demo/app/generate-fake-data.js
+++ b/demo/app/generate-fake-data.js
@@ -10,6 +10,7 @@ export default function (groupCount = 30, itemCount = 1000, daysInPast = 30) {
       id: `${i + 1}`,
       title: faker.name.firstName(),
       rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
       bgColor: randomColor({ luminosity: 'light', seed: randomSeed + i })
     })
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/namespace-ee/react-calendar-timeline",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sky-uk/react-calendar-timeline.git"
+    "url": "https://github.com/namespace-ee/react-calendar-timeline.git"
   },
   "author": "Marius Andra <marius.andra@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/namespace-ee/react-calendar-timeline",
   "repository": {
     "type": "git",
-    "url": "https://github.com/namespace-ee/react-calendar-timeline.git"
+    "url": "https://github.com/sky-uk/react-calendar-timeline.git"
   },
   "author": "Marius Andra <marius.andra@gmail.com>",
   "contributors": [

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -88,6 +88,7 @@ export default class ReactCalendarTimeline extends Component {
     keys: PropTypes.shape({
       groupIdKey: PropTypes.string,
       groupTitleKey: PropTypes.string,
+      groupLabelKey: PropTypes.string,
       groupRightTitleKey: PropTypes.string,
       itemIdKey: PropTypes.string,
       itemTitleKey: PropTypes.string,
@@ -648,7 +649,7 @@ export default class ReactCalendarTimeline extends Component {
       draggingItem: item,
       dragTime: dragTime,
       newGroupOrder: newGroupOrder,
-      dragGroupTitle: newGroup ? _get(newGroup, keys.groupTitleKey) : ''
+      dragGroupTitle: newGroup ? _get(newGroup, keys.groupLabelKey) : ''
     })
   }
 

--- a/src/lib/default-config.js
+++ b/src/lib/default-config.js
@@ -2,6 +2,7 @@ export const defaultKeys = {
   groupIdKey: 'id',
   groupTitleKey: 'title',
   groupRightTitleKey: 'rightTitle',
+  groupLabelKey: 'title',
   itemIdKey: 'id',
   itemTitleKey: 'title',
   itemDivTitleKey: 'title',


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/442#issue-367851639

**Overview of PR**

The fix involves introducing a new key in the Timeline keys object called `groupLabelKey`, which is defaulted to `title`. This will preserve existing functionality. When the `groupLabelKey` is specified to point to a string attribute of the group object, that is used to render the text in the InfoLabel.

This allows the developer to split what is used to render the Sidebar with what is used to render the InfoLabel.