### PR TITLE
use 'rct' prefix for class names of Header children

### DIFF
--- a/src/lib/Timeline.scss
+++ b/src/lib/Timeline.scss
@@ -77,8 +77,8 @@ $weekend: rgba(250, 246, 225, 0.5);
     overflow-x: hidden;
     z-index: 90;
 
-    .top-header,
-    .bottom-header {
+    .rct-top-header,
+    .rct-bottom-header {
       position: relative;
     }
 
@@ -127,7 +127,7 @@ $weekend: rgba(250, 246, 225, 0.5);
       }
     }
   }
- 
+
   .rct-sidebar-header {
     margin: 0;
     color: $sidebar-color;

--- a/src/lib/layout/TimelineElementsHeader.js
+++ b/src/lib/layout/TimelineElementsHeader.js
@@ -232,13 +232,13 @@ export default class TimelineElementsHeader extends Component {
         ref={this.props.scrollHeaderRef}
       >
         <div
-          className="top-header"
+          className="rct-top-header"
           style={{ height: twoHeaders ? headerLabelGroupHeight : 0, width: canvasWidth }}
         >
           {topHeaderLabels}
         </div>
         <div
-          className="bottom-header"
+          className="rct-bottom-header"
           style={{ height: headerLabelHeight, width: canvasWidth }}
         >
           {bottomHeaderLabels}


### PR DESCRIPTION
**Overview of PR**

For most of CSS classes prefix `rct` is used to avoid styling issues. Two children of Header `top-header` and `top-header` currently are missing this prefix which this PR adds.