### PR TITLE
Fix documentation for verticalLineClassNamesForTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,15 +607,18 @@ An example could look like (see: demo/vertical-classes):
 verticalLineClassNamesForTime = (timeStart, timeEnd) => {
   const currentTimeStart = moment(timeStart)
   const currentTimeEnd = moment(timeEnd)
+  let holidayArray = []
 
   for (let holiday of holidays) {
     if (
       holiday.isSame(currentTimeStart, 'day') &&
       holiday.isSame(currentTimeEnd, 'day')
     ) {
-      return ['holiday']
+      holidayArray.push('holiday')
     }
   }
+
+  return holidayArray
 }
 ```
 


### PR DESCRIPTION
**Issue Number**

#452 

The documentation for verticalLineClassNamesForTime as previously written includes a code sample that returns only the first holiday in the list of holidays.

**Overview of PR**

After this change, the sample code in the documentation will return all holidays in the range, per the description for this function.
