### PR TITLE
Fix to force re-render on zoom change

### DIFF
--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -489,11 +489,13 @@ props,
 state) {
   const oldCanvasTimeStart = state.canvasTimeStart
   const oldZoom = state.visibleTimeEnd - state.visibleTimeStart
+  const newZoom = visibleTimeEnd - visibleTimeStart;
 
   const newState = { visibleTimeStart, visibleTimeEnd }
 
   // Check if the current canvas covers the new times
   const canKeepCanvas =
+    oldZoom !== newZoom ||
     visibleTimeStart >= oldCanvasTimeStart + oldZoom * 0.5 &&
     visibleTimeStart <= oldCanvasTimeStart + oldZoom * 1.5 &&
     visibleTimeEnd >= oldCanvasTimeStart + oldZoom * 1.5 &&


### PR DESCRIPTION
**Issue Number**

#455 

**Overview of PR**

Forces canvas to re-draw when the zoom level changes.
On MacOS the zoom level changes a small amount on zoom. This causes the timeline items to not update and appear to 'drift' on the timeline.

