### PR TITLE
Wrap timeline in flex container

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1006,64 +1006,67 @@ export default class ReactCalendarTimeline extends Component {
               headerLabelGroupHeight,
               headerLabelHeight
             )}
-            {sidebarWidth > 0 && this.sidebar(height, groupHeights, headerHeight)}
-            <div style={{display: 'inline-block'}}>
 
-              <div style={outerComponentStyle} className="rct-outer">
-              <ScrollElement
-              scrollRef={el => {
-                this.props.scrollRef(el);
-                this.scrollComponent = el
-              }}
-                width={width}
-                height={height}
-                onZoom={this.changeZoom}
-                onWheelZoom={this.handleWheelZoom}
-                traditionalZoom={traditionalZoom}
-                onScroll={this.onScroll}
-                isInteractingWithItem={isInteractingWithItem}
-              >
-              <MarkerCanvas>
-                  {this.items(
-                    canvasTimeStart,
-                    zoom,
-                    canvasTimeEnd,
-                    canvasWidth,
-                    minUnit,
-                    dimensionItems,
-                    groupHeights,
-                    groupTops
-                  )}
-                {this.columns(
-                    canvasTimeStart,
-                    canvasTimeEnd,
-                    canvasWidth,
-                    minUnit,
-                    timeSteps,
-                    height,
-                    headerHeight
-                  )}
-                {this.rows(canvasWidth, groupHeights, groups)}
-                  {this.infoLabel()}
-                  {this.childrenWithProps(
-                    canvasTimeStart,
-                    canvasTimeEnd,
-                    canvasWidth,
-                    dimensionItems,
-                    groupHeights,
-                    groupTops,
-                    height,
-                    headerHeight,
-                    visibleTimeStart,
-                    visibleTimeEnd,
-                    minUnit,
-                    timeSteps
-                  )}
-              </MarkerCanvas>
-              </ScrollElement>
+            <div style={{display: 'flex'}}>
+              {sidebarWidth > 0 && this.sidebar(height, groupHeights, headerHeight)}
+              <div style={{display: 'inline-block'}}>
+
+                <div style={outerComponentStyle} className="rct-outer">
+                <ScrollElement
+                scrollRef={el => {
+                  this.props.scrollRef(el);
+                  this.scrollComponent = el
+                }}
+                  width={width}
+                  height={height}
+                  onZoom={this.changeZoom}
+                  onWheelZoom={this.handleWheelZoom}
+                  traditionalZoom={traditionalZoom}
+                  onScroll={this.onScroll}
+                  isInteractingWithItem={isInteractingWithItem}
+                >
+                <MarkerCanvas>
+                    {this.items(
+                      canvasTimeStart,
+                      zoom,
+                      canvasTimeEnd,
+                      canvasWidth,
+                      minUnit,
+                      dimensionItems,
+                      groupHeights,
+                      groupTops
+                    )}
+                  {this.columns(
+                      canvasTimeStart,
+                      canvasTimeEnd,
+                      canvasWidth,
+                      minUnit,
+                      timeSteps,
+                      height,
+                      headerHeight
+                    )}
+                  {this.rows(canvasWidth, groupHeights, groups)}
+                    {this.infoLabel()}
+                    {this.childrenWithProps(
+                      canvasTimeStart,
+                      canvasTimeEnd,
+                      canvasWidth,
+                      dimensionItems,
+                      groupHeights,
+                      groupTops,
+                      height,
+                      headerHeight,
+                      visibleTimeStart,
+                      visibleTimeEnd,
+                      minUnit,
+                      timeSteps
+                    )}
+                </MarkerCanvas>
+                </ScrollElement>
+                </div>
               </div>
+              {rightSidebarWidth > 0 && this.rightSidebar(height, groupHeights, headerHeight)}
             </div>
-            {rightSidebarWidth > 0 && this.rightSidebar(height, groupHeights, headerHeight)}
           </div>
         </TimelineMarkersProvider>
       </TimelineStateProvider>


### PR DESCRIPTION
Firstly, I'm new to this so apologies if I'm not doing this right!

**Overview of PR**

Just wrapping the timeline in a flex container in the same way that the header is wrapped in a flex container. 

I think there are sometimes issues with the way the width of the viewport is calculated, which in some circumstances can make the timeline go onto two rows like the screenshot below. Resizing the screen forces a recalculation and it renders properly. You can also see this in the codesandbox examples if you slowly resize the preview pane to be smaller, the items jump down (to be in the same position as this screenshot) then they re-render to be in the right place. 

Wrapping the sidebar and timeline in a flex container allows the siderbar to shrink, in the same way that the header sidebar shrinks, and always keeps the timeline on the same row

![image](https://user-images.githubusercontent.com/34010145/48838050-198b7700-ed7f-11e8-8892-da9521d89b96.png)


