### PR TITLE
Fix sidebar re-render when groupHeights do not change

### DIFF
--- a/src/lib/layout/Sidebar.js
+++ b/src/lib/layout/Sidebar.js
@@ -16,11 +16,11 @@ export default class Sidebar extends Component {
 
   shouldComponentUpdate(nextProps) {
     return !(
-      arraysEqual(nextProps.groups, this.props.groups) &&
       nextProps.keys === this.props.keys &&
       nextProps.width === this.props.width &&
-      nextProps.groupHeights === this.props.groupHeights &&
-      nextProps.height === this.props.height
+      nextProps.height === this.props.height &&
+      arraysEqual(nextProps.groups, this.props.groups) &&
+      arraysEqual(nextProps.groupHeights, this.props.groupHeights)
     )
   }
 


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/478

**Overview of PR**

Changed equality comparison of groupHeights to use arraysEquals utility function instead. This will prevent re-render's of sidebar when groupHeights doesn't change.

Also moved arraysEqual checks after the equality comparisons to take advantage of short circuiting.
