### PR TITLE
Update calendar.js

### DIFF
--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -220,7 +220,7 @@ export function calculateDimensions({
     effectiveStartTime: effectiveStartTime,
     effectiveEndTime: effectiveEndTime,
     itemTimeStart: itemTimeStart,
-    itemEnd: itemEnd
+    itemTimeEnd: itemTimeEnd
   }
 
   return dimensions

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -216,7 +216,11 @@ export function calculateDimensions({
     left: left,
     width: Math.max(itemWidth, 3),
     collisionLeft: itemTimeStart,
-    collisionWidth: itemTimeRange
+    collisionWidth: itemTimeRange,
+    effectiveStartTime: effectiveStartTime,
+    effectiveEndTime: effectiveEndTime,
+    itemTimeStart: itemTimeStart,
+    itemEnd: itemEnd
   }
 
   return dimensions


### PR DESCRIPTION
Include time data in the item dimension object.

Main reason to allow a custom itemRenderer to display more information within an item, and display that info correctly in case the timeline is zoomed in and the item width is cut off.

Eg. something like a horizontal candle chart as an item.