### PR TITLE
docs: adding link to LICENSE.md to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ You need to include the `Timeline.css` file, either via static file reference or
 
 ## How can I have items with different colors?
 
-Now you can use item renderer for rendering items with different colors [itemRenderer](https://github.com/namespace-ee/react-calendar-timeline#itemrenderer). 
+Now you can use item renderer for rendering items with different colors [itemRenderer](https://github.com/namespace-ee/react-calendar-timeline#itemrenderer).
 Please refer to [examples](https://github.com/namespace-ee/react-calendar-timeline/tree/master/examples#custom-item-rendering) for a sandbox example
 
 ## How can I add a sidebar on the right?
@@ -917,3 +917,6 @@ npm version patch
 ```
 
 -->
+
+## License
+[MIT licensed](/LICENSE.md).


### PR DESCRIPTION
**Issue Number**

There is no issue related to this PR - I'm submitting this PR to make it easier for anyone who sees the README.md that `react-calendar-timeline` is MIT licensed.

**Overview of PR**

Not sure if I should update CHANGELOG.md for this small change? Happy to do it though if needed.

---

Thanks for all the work with this repo 💯 