### PR TITLE
feat(Timeline): Add UTC offset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Change Log
 
 All notable changes to this project will be documented in this file.
@@ -6,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres (more or less) to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### 0.24.0
+
+### Added
+
+* utc offset support
 
 ## 0.23.0
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ The exact viewport of the calendar. When these are specified, scrolling in the c
 
 **Note that you need to provide either `defaultTimeStart/End` or `visibleTimeStart/End` for the timeline to function**
 
+## utcOffset
+
+Define the offset you want to apply from UTC. Defaults value is your local timezone offset (e.g. moment().utcOffset())
+
 ## selected
 
 An array with id's corresponding to id's in items (`item.id`). If this prop is set you have to manage the selected items yourself within the `onItemSelect` handler to update the property with new id's. This overwrites the default behaviour of selecting one item on click.
@@ -696,6 +700,10 @@ Marker that is placed on the current date/time.
 > interval: number | default: 10000
 
 How often the TodayMarker refreshes. Value represents milliseconds.
+
+> applyLocalOffset: boolean | default: true
+
+If you want to apply the local timezone offset when you display some informations (e.g. the today marker). This option is often correlated with `utcOffset` option, and should be provided to the `<Timeline>` component.
 
 > children: function({styles: object, date: number}) => JSX.Element
 

--- a/__tests__/components/Header/Header.test.js
+++ b/__tests__/components/Header/Header.test.js
@@ -22,6 +22,7 @@ const defaultProps = {
   stickyHeader: true,
   headerLabelGroupHeight: 15,
   headerLabelHeight: 15,
+  utcOffset: 0,
   scrollHeaderRef: () => {},
   headerRef: () => {}
 }

--- a/__tests__/components/Header/TimelineElementsHeader.test.js
+++ b/__tests__/components/Header/TimelineElementsHeader.test.js
@@ -16,6 +16,7 @@ const defaultProps = {
   subHeaderLabelFormats: {},
   headerLabelGroupHeight: 0,
   headerLabelHeight: 0,
+  utcOffset: 0,
   scrollHeaderRef: () => {}
 }
 

--- a/__tests__/components/Markers/CustomMarker.test.js
+++ b/__tests__/components/Markers/CustomMarker.test.js
@@ -67,7 +67,9 @@ describe('CustomMarker', () => {
       visibleTimeEnd,
       canvasTimeStart: visibleTimeStart - oneDay,
       canvasTimeEnd: visibleTimeEnd + oneDay,
-      canvasWidth
+      canvasWidth,
+      utcOffset: 0,
+      applyLocalOffset: false
     }
 
     const markerDate = now + oneDay / 2

--- a/__tests__/test-utility/marker-renderer.js
+++ b/__tests__/test-utility/marker-renderer.js
@@ -15,7 +15,9 @@ export const RenderWrapper = ({ children, timelineState }) => {
     canvasTimeStart: visibleTimeStart - oneDay,
     canvasTimeEnd: visibleTimeEnd + oneDay,
     canvasWidth: 3000,
-    visibleWidth: 1000
+    visibleWidth: 1000,
+    utcOffset: 0,
+    applyLocalOffset: false
   }
 
   timelineState = timelineState != null ? timelineState : defaultTimelineState

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -171,6 +171,8 @@ export default class App extends Component {
         onItemDoubleClick={this.handleItemDoubleClick}
         onTimeChange={this.handleTimeChange}
         moveResizeValidator={this.moveResizeValidator}
+        // utcOffset={0} // set all the calendar timeline as UTC calendar
+        // applyLocalOffset={true} // keep the TodayMarker in the local reference
       >
         <TimelineMarkers>
           <TodayMarker />

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -41,6 +41,9 @@ export default class ReactCalendarTimeline extends Component {
     rightSidebarWidth: PropTypes.number,
     rightSidebarContent: PropTypes.node,
     dragSnap: PropTypes.number,
+    utcOffset: PropTypes.number,
+    applyLocalOffset: PropTypes.bool,
+    infoLabelFormat: PropTypes.string,
     minResizeWidth: PropTypes.number,
     stickyOffset: PropTypes.number,
     stickyHeader: PropTypes.bool,
@@ -166,6 +169,9 @@ export default class ReactCalendarTimeline extends Component {
     sidebarWidth: 150,
     rightSidebarWidth: 0,
     dragSnap: 1000 * 60 * 15, // 15min
+    utcOffset: moment().utcOffset(),
+    applyLocalOffset: false,
+    infoLabelFormat: 'LLL',
     minResizeWidth: 20,
     stickyOffset: 0,
     stickyHeader: true,
@@ -710,6 +716,7 @@ export default class ReactCalendarTimeline extends Component {
         timeSteps={timeSteps}
         height={height}
         verticalLineClassNamesForTime={this.props.verticalLineClassNamesForTime}
+        utcOffset={this.props.utcOffset}
       />
     )
   }
@@ -817,16 +824,15 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   infoLabel() {
-    let label = null
-
-    if (this.state.dragTime) {
-      label = `${moment(this.state.dragTime).format('LLL')}, 
-        ${this.state.dragGroupTitle}`
-    } else if (this.state.resizeTime) {
-      label = moment(this.state.resizeTime).format('LLL')
-    }
+    const {
+      props: { utcOffset, infoLabelFormat },
+      state: { dragTime, resizeTime, dragGroupTitle }
+    } = this
+    const label = dragTime || resizeTime
+    const labelComplement = dragTime ? ` - ${dragGroupTitle}` : ''
+    const computedLabel = moment(label).utcOffset(utcOffset).format(infoLabelFormat) + labelComplement
     
-    return label ? <InfoLabel label={label} /> : undefined
+    return label && <InfoLabel label={computedLabel} />
   }
 
   handleHeaderRef = el => {
@@ -869,6 +875,7 @@ export default class ReactCalendarTimeline extends Component {
         rightSidebarWidth={this.props.rightSidebarWidth}
         leftSidebarHeader={this.props.sidebarContent}
         rightSidebarHeader={this.props.rightSidebarContent}
+        utcOffset={this.props.utcOffset}
       />
     )
   }
@@ -1020,6 +1027,8 @@ export default class ReactCalendarTimeline extends Component {
         canvasTimeStart={canvasTimeStart}
         canvasTimeEnd={canvasTimeEnd}
         canvasWidth={canvasWidth}
+        utcOffset={this.props.utcOffset}
+        applyLocalOffset={this.props.applyLocalOffset}
       >
         <TimelineMarkersProvider>
           <div

--- a/src/lib/columns/Columns.js
+++ b/src/lib/columns/Columns.js
@@ -12,7 +12,8 @@ export default class Columns extends Component {
     minUnit: PropTypes.string.isRequired,
     timeSteps: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired,
-    verticalLineClassNamesForTime: PropTypes.func
+    verticalLineClassNamesForTime: PropTypes.func,
+    utcOffset: PropTypes.number.isRequired
   }
 
   shouldComponentUpdate(nextProps) {
@@ -37,7 +38,8 @@ export default class Columns extends Component {
       minUnit,
       timeSteps,
       height,
-      verticalLineClassNamesForTime
+      verticalLineClassNamesForTime,
+      utcOffset
     } = this.props
     const ratio = canvasWidth / (canvasTimeEnd - canvasTimeStart)
 
@@ -47,6 +49,7 @@ export default class Columns extends Component {
       canvasTimeStart,
       canvasTimeEnd,
       minUnit,
+      utcOffset,
       timeSteps,
       (time, nextTime) => {
         const left = Math.round((time.valueOf() - canvasTimeStart) * ratio, -2)

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -23,7 +23,8 @@ class Header extends Component {
     leftSidebarWidth: PropTypes.number,
     rightSidebarWidth: PropTypes.number,
     headerRef: PropTypes.func.isRequired,
-    scrollHeaderRef: PropTypes.func.isRequired
+    scrollHeaderRef: PropTypes.func.isRequired,
+    utcOffset: PropTypes.number.isRequired
   }
 
   render() {
@@ -47,7 +48,8 @@ class Header extends Component {
       leftSidebarHeader,
       rightSidebarHeader,
       leftSidebarWidth,
-      rightSidebarWidth
+      rightSidebarWidth,
+      utcOffset
     } = this.props
 
     const headerStyle = {
@@ -98,7 +100,7 @@ class Header extends Component {
             headerLabelGroupHeight={headerLabelGroupHeight}
             headerLabelHeight={headerLabelHeight}
             scrollHeaderRef={scrollHeaderRef}
-
+            utcOffset={utcOffset}
           />
         </div>
         {rightSidebar}

--- a/src/lib/layout/TimelineElementsHeader.js
+++ b/src/lib/layout/TimelineElementsHeader.js
@@ -18,7 +18,8 @@ export default class TimelineElementsHeader extends Component {
     subHeaderLabelFormats: PropTypes.object.isRequired,
     headerLabelGroupHeight: PropTypes.number.isRequired,
     headerLabelHeight: PropTypes.number.isRequired,
-    scrollHeaderRef: PropTypes.func.isRequired
+    scrollHeaderRef: PropTypes.func.isRequired,
+    utcOffset: PropTypes.number.isRequired
   }
 
   constructor(props) {
@@ -116,7 +117,8 @@ export default class TimelineElementsHeader extends Component {
       timeSteps,
       headerLabelGroupHeight,
       headerLabelHeight,
-      hasRightSidebar
+      hasRightSidebar,
+      utcOffset
     } = this.props
 
     const ratio = canvasWidth / (canvasTimeEnd - canvasTimeStart)
@@ -131,6 +133,7 @@ export default class TimelineElementsHeader extends Component {
         canvasTimeStart,
         canvasTimeEnd,
         nextUnit,
+        utcOffset,
         timeSteps,
         (time, nextTime) => {
           const left = Math.round((time.valueOf() - canvasTimeStart) * ratio)
@@ -174,6 +177,7 @@ export default class TimelineElementsHeader extends Component {
       canvasTimeStart,
       canvasTimeEnd,
       minUnit,
+      utcOffset,
       timeSteps,
       (time, nextTime) => {
         const left = Math.round((time.valueOf() - canvasTimeStart) * ratio)

--- a/src/lib/markers/TimelineMarkersRenderer.js
+++ b/src/lib/markers/TimelineMarkersRenderer.js
@@ -10,7 +10,7 @@ import CursorMarker from './implementations/CursorMarker'
 const TimelineMarkersRenderer = () => {
   return (
     <TimelineStateConsumer>
-      {({ getLeftOffsetFromDate }) => (
+      {({ getLeftOffsetFromDate, utcOffset, applyLocalOffset }) => (
         <TimelineMarkersConsumer>
           {({ markers }) => {
             return markers.map(marker => {
@@ -22,6 +22,8 @@ const TimelineMarkersRenderer = () => {
                       getLeftOffsetFromDate={getLeftOffsetFromDate}
                       renderer={marker.renderer}
                       interval={marker.interval}
+                      utcOffset={utcOffset}
+                      applyLocalOffset={applyLocalOffset}
                     />
                   )
                 case TimelineMarkerType.Custom:
@@ -31,6 +33,7 @@ const TimelineMarkersRenderer = () => {
                       renderer={marker.renderer}
                       date={marker.date}
                       getLeftOffsetFromDate={getLeftOffsetFromDate}
+                      utcOffset={utcOffset}
                     />
                   )
                 case TimelineMarkerType.Cursor:
@@ -39,6 +42,7 @@ const TimelineMarkersRenderer = () => {
                       key={marker.id}
                       renderer={marker.renderer}
                       getLeftOffsetFromDate={getLeftOffsetFromDate}
+                      utcOffset={utcOffset}
                     />
                   )
                 default:

--- a/src/lib/markers/implementations/TodayMarker.js
+++ b/src/lib/markers/implementations/TodayMarker.js
@@ -14,15 +14,20 @@ class TodayMarker extends React.Component {
   static propTypes = {
     getLeftOffsetFromDate: PropTypes.func.isRequired,
     renderer: PropTypes.func,
-    interval: PropTypes.number.isRequired
+    interval: PropTypes.number.isRequired,
+    applyLocalOffset: PropTypes.bool.isRequired
   }
 
   static defaultProps = {
     renderer: defaultRenderer
   }
 
-  state = {
-    date: Date.now()
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      date: this.getDate()
+    }
   }
 
   componentDidMount() {
@@ -39,10 +44,15 @@ class TodayMarker extends React.Component {
   createIntervalUpdater(interval) {
     return setInterval(() => {
       this.setState({
-        date: Date.now() // FIXME: use date utils pass in as props
+        date: this.getDate()
       });
     }, interval);
   }
+
+  // FIXME: use date utils pass in as props
+  getDate = () => this.props.applyLocalOffset
+    ? Date.now() - (new Date().getTimezoneOffset() * 60 * 1000)
+    : Date.now()
 
   componentWillUnmount() {
     clearInterval(this.intervalToken)

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -33,9 +33,8 @@ class ScrollElement extends Component {
   }
 
   handleWheel = e => {
+    // FIXME: should be used somewhere... 
     const { traditionalZoom } = this.props
-
-    
 
     // zoom in the time dimension
     if (e.ctrlKey || e.metaKey || e.altKey) {

--- a/src/lib/timeline/TimelineStateContext.js
+++ b/src/lib/timeline/TimelineStateContext.js
@@ -37,7 +37,9 @@ export class TimelineStateProvider extends React.Component {
     visibleTimeEnd: PropTypes.number.isRequired,
     canvasTimeStart: PropTypes.number.isRequired,
     canvasTimeEnd: PropTypes.number.isRequired,
-    canvasWidth: PropTypes.number.isRequired
+    canvasWidth: PropTypes.number.isRequired,
+    utcOffset: PropTypes.number.isRequired,
+    applyLocalOffset: PropTypes.bool.isRequired
   }
 
   constructor(props) {
@@ -47,14 +49,14 @@ export class TimelineStateProvider extends React.Component {
       timelineContext: {
         getTimelineState: this.getTimelineState,
         getLeftOffsetFromDate: this.getLeftOffsetFromDate,
-        getDateFromLeftOffsetPosition: this.getDateFromLeftOffsetPosition
+        getDateFromLeftOffsetPosition: this.getDateFromLeftOffsetPosition,
+        utcOffset: this.props.utcOffset,
+        applyLocalOffset: this.props.applyLocalOffset
       }
     }
   }
 
-  getTimelineState = () => {
-    return this.state.timelineState // REVIEW: return copy or object.freeze?
-  }
+  getTimelineState = () => ({ ...this.state })
 
   getLeftOffsetFromDate = date => {
     const { canvasTimeStart, canvasTimeEnd, canvasWidth } = this.props

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -59,8 +59,8 @@ export function calculateTimeForXPosition(
   return timeFromCanvasTimeStart + canvasTimeStart
 }
 
-export function iterateTimes(start, end, unit, timeSteps, callback) {
-  let time = moment(start).startOf(unit)
+export function iterateTimes(start, end, unit, utcOffset, timeSteps, callback) {
+  let time = moment(start).utcOffset(utcOffset).startOf(unit)
 
   if (timeSteps[unit] && timeSteps[unit] > 1) {
     let value = time.get(unit)
@@ -68,7 +68,7 @@ export function iterateTimes(start, end, unit, timeSteps, callback) {
   }
 
   while (time.valueOf() < end) {
-    let nextTime = moment(time).add(timeSteps[unit] || 1, `${unit}s`)
+    const nextTime = moment(time).utcOffset(utcOffset).add(timeSteps[unit] || 1, `${unit}s`)
     callback(time, nextTime)
     time = nextTime
   }


### PR DESCRIPTION
**Issue Number**
https://github.com/namespace-ee/react-calendar-timeline/issues/512

**Overview of PR**

This PR will add an UTC offset support to the whole calendar timeline.

`utcOffset` and `applyLocalOffset` prop have been added to the library.
They permit to set an offset from UTC (`utcOffset`), and to keep some informations (markers) correlated to the local timezone offset (`applyLocalOffset`). 