### PR TITLE
add props infoLabelRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## 0.23.0
 
-- improve unit tests coverage #426 - @ilaiwi
-- stack items by group #384 - @acemac
-- fix bug where `canMove` prop gets ignored #484 - @acemac + @ilaiwi
-- fix sidebar re-render when groupHeights do not change #478 - @SDupZ
+* improve unit tests coverage #426 - @ilaiwi
+* stack items by group #384 - @acemac
+* fix bug where `canMove` prop gets ignored #484 - @acemac + @ilaiwi
+* fix sidebar re-render when groupHeights do not change #478 - @SDupZ
+* add props `infoLabelRenderer(action, itemId, time, newGroupOrderOrResizingEdge)`
 
 ### Stack per group
 
@@ -59,15 +60,14 @@ ReactDOM.render(
 )
 ```
 
-
 ## 0.22.0
 
 ### Fixed
 
 * Provided a new key `groupLabelKey` to allow splitting of the key used to render the Sidebar and the InfoLabel visible during drag operations. `groupTitleKey` continues to be used to render the Sidebar. #442 @thiagosatoshi
-* fix scroll left/right causes item move/edit to be at incorrect time #401 @acemac 
-* now `getResizeProps` take `leftClassName` and `rightClassName` and returns className for left and right props @acemac 
-* fix functionality of `itemTitle` and `itemDivTitle` [issue](https://github.com/namespace-ee/react-calendar-timeline/issues/429#issuecomment-426456693) @acemac 
+* fix scroll left/right causes item move/edit to be at incorrect time #401 @acemac
+* now `getResizeProps` take `leftClassName` and `rightClassName` and returns className for left and right props @acemac
+* fix functionality of `itemTitle` and `itemDivTitle` [issue](https://github.com/namespace-ee/react-calendar-timeline/issues/429#issuecomment-426456693) @acemac
 
 ### 0.21.0
 
@@ -84,9 +84,11 @@ ReactDOM.render(
 ### 0.20.0
 
 ### improvements
+
 * eliminate extra renders on every scroll - #357 [acemac](https://github.com/acemac)
 
 ### Fixed
+
 * When the `date` prop on a `CustomMarker` changes the marker will now move on the timeline - #421 [kevinmanncito](https://github.com/kevinmanncito) [ilaiwi](https://github.com/ilaiwi)
 * Header has a bounce effect - #311 [acemac](https://github.com/acemac)
 
@@ -94,8 +96,6 @@ ReactDOM.render(
 
 * update to `react-testing-library` version 5
 * remove deprecated `toBeInDom`
-
-
 
 ### 0.19.0
 
@@ -135,7 +135,7 @@ ReactDOM.render(
 
 ### Breaking
 
-* Removed support for React 15 and lower.  This is due to the fact that 16+ supports returning arrays from render, something that the TimelineMarker feature relies on.
+* Removed support for React 15 and lower. This is due to the fact that 16+ supports returning arrays from render, something that the TimelineMarker feature relies on.
 * removed `showCursorLine` prop in favor of using the `CursorMarker` component. See `TimelineMarkers` section of README for documentation.
 
 ```diff
@@ -159,6 +159,7 @@ from 'react-calendar-timeline'
 ### 0.17.3
 
 ### Added
+
 * fix issue with single row header - #359
 
 ### 0.17.2

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Append a special `.rct-drag-right` handle to the elements and only resize if dra
 
 ### stackItems
 
-Stack items under each other, so there is no visual overlap when times collide.  Can be overridden in the `groups` array. Defaults to `false`.
+Stack items under each other, so there is no visual overlap when times collide. Can be overridden in the `groups` array. Defaults to `false`.
 
 ## traditionalZoom
 
@@ -468,12 +468,12 @@ Paramters provided to the function has two types: context params which have the 
 | `selected`        | `boolean`       | returns if the item is selected.                                                                                                                                          |
 | `dragging`        | `boolean`       | returns if the item is being dragged                                                                                                                                      |
 | `dragStart`       | `object`        | returns `x` and `y` of the start dragging point of the item.                                                                                                              |
-| `dragTime`       | `number`        |  current drag time.                                                                                                              |
+| `dragTime`        | `number`        | current drag time.                                                                                                                                                        |
 | `dragGroupDelta`  | `number`        | returns number of groups the item moved. if negative, moving was to top. If positive, moving was to down                                                                  |
 | `resizing`        | `boolean`       | returns if the item is being resized.                                                                                                                                     |
 | `resizeEdge`      | `left`, `right` | the side from which the component is being resized form                                                                                                                   |
 | `resizeStart`     | `number`        | returns the x value from where the component start moving                                                                                                                 |
-| `resizeTime`     | `number`        | current resize time                                                                                                                 |
+| `resizeTime`      | `number`        | current resize time                                                                                                                                                       |
 | `width`           | `boolean`       | returns the width of the item (same as in dimensions)                                                                                                                     |
 
 ##### prop getters functions
@@ -593,6 +593,35 @@ groupRenderer = ({ group }) => {
       <p className="tip">{group.tip}</p>
     </div>
   )
+}
+```
+
+## infoLabelRenderer(action, itemId, time, newGroupOrderOrResizingEdge)
+
+React component that will be used to render the content of infoLabel while moving or resizing items.
+
+The argument `action` is one of `move` or `resize`.
+
+The argument `time` describes the proposed new time for either the start time of the item (for move) or the start or end time (for resize).
+
+The argument `newGroupOrderOrResizingEdge` is the group order (for move), or one of `left` or `right` (for resize).
+
+The function should return a string or a react component, or `null` for disabling infoLabel.
+
+For example, use this code:
+
+```jsx
+infoLabelRenderer = (action, itemId, time, newGroupOrderOrResizingEdge) => {
+  let label = null
+  if (action == 'move') {
+    let newGroup = this.state.groups[newGroupOrderOrResizingEdge]
+    const groupLabel = newGroup ? newGroup.title : ''
+    label = `${moment(this.state.dragTime).format('LLL')},
+        ${groupLabel}`
+  } else if (action == 'resize') {
+    label = `${moment(time).format('LLL')}, ${newGroupOrderOrResizingEdge}`
+  }
+  return label
 }
 ```
 
@@ -785,7 +814,7 @@ You need to include the `Timeline.css` file, either via static file reference or
 
 ## How can I have items with different colors?
 
-Now you can use item renderer for rendering items with different colors [itemRenderer](https://github.com/namespace-ee/react-calendar-timeline#itemrenderer). 
+Now you can use item renderer for rendering items with different colors [itemRenderer](https://github.com/namespace-ee/react-calendar-timeline#itemrenderer).
 Please refer to [examples](https://github.com/namespace-ee/react-calendar-timeline/tree/master/examples#custom-item-rendering) for a sandbox example
 
 ## How can I add a sidebar on the right?

--- a/demo/app/demo-custom-items/index.js
+++ b/demo/app/demo-custom-items/index.js
@@ -16,6 +16,7 @@ var maxTime = moment()
 var keys = {
   groupIdKey: 'id',
   groupTitleKey: 'title',
+  groupLabelKey: 'title',
   groupRightTitleKey: 'rightTitle',
   itemIdKey: 'id',
   itemTitleKey: 'title',
@@ -155,7 +156,7 @@ export default class App extends Component {
             borderLeftWidth: itemContext.selected ? 3 : 1,
             borderRightWidth: itemContext.selected ? 3 : 1,
           }
-        }) }
+        })}
       >
         {itemContext.useResizeHandle ? (
           <div {...leftResizeProps} />
@@ -165,7 +166,7 @@ export default class App extends Component {
           style={{
             height: itemContext.dimensions.height,
             overflow: 'hidden',
-            paddingLeft:3,
+            paddingLeft: 3,
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap'
           }}
@@ -188,6 +189,20 @@ export default class App extends Component {
   //     </div>
   //   )
   // }
+
+  infoLabelRenderer = (action, itemId, time, newGroupOrderOrResizingEdge) => {
+    let label = null
+    if (action == 'move') {
+      let newGroup = this.state.groups[newGroupOrderOrResizingEdge]
+      const groupLabel = newGroup ? newGroup.title : ''
+      label = `${moment(this.state.dragTime).format('LLL')},
+        ${groupLabel}`
+    } else if (action == 'resize') {
+      label = `${moment(time).format('LLL')}, ${newGroupOrderOrResizingEdge}`
+    }
+    return label
+  }
+
 
   render() {
     const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
@@ -217,6 +232,7 @@ export default class App extends Component {
         defaultTimeEnd={defaultTimeEnd}
         itemRenderer={this.itemRenderer}
         // groupRenderer={this.groupRenderer}
+        infoLabelRenderer={this.infoLabelRenderer}
 
         onCanvasClick={this.handleCanvasClick}
         onCanvasContextMenu={this.handleCanvasContextMenu}


### PR DESCRIPTION
**Issue Number**

#517

**Overview of PR**

added props `infoLabelRenderer` to allow user customize info label when dragging an item

(the contents below are also added to README.md)


## infoLabelRenderer(action, itemId, time, newGroupOrderOrResizingEdge)

React component that will be used to render the content of infoLabel while moving or resizing items.

The argument `action` is one of `move` or `resize`.

The argument `time` describes the proposed new time for either the start time of the item (for move) or the start or end time (for resize).

The argument `newGroupOrderOrResizingEdge` is the group order (for move), or one of `left` or `right` (for resize).

The function should return a string or a react component, or `null` for disabling infoLabel.

For example, use this code:

```jsx
infoLabelRenderer = (action, itemId, time, newGroupOrderOrResizingEdge) => {
  let label = null
  if (action == 'move') {
    let newGroup = this.state.groups[newGroupOrderOrResizingEdge]
    const groupLabel = newGroup ? newGroup.title : ''
    label = `${moment(this.state.dragTime).format('LLL')},
        ${groupLabel}`
  } else if (action == 'resize') {
    label = `${moment(time).format('LLL')}, ${newGroupOrderOrResizingEdge}`
  }
  return label
}
```
