### PR TITLE
TimelineMarkers: Unsubscribing markers correctly when hidden

### DIFF
--- a/__tests__/components/Markers/TimelineMarkers.test.js
+++ b/__tests__/components/Markers/TimelineMarkers.test.js
@@ -3,6 +3,7 @@ import { render } from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import TimelineMarkers from 'lib/markers/public/TimelineMarkers'
 import TodayMarker from 'lib/markers/public/TodayMarker'
+import CustomMarker from 'lib/markers/public/CustomMarker'
 import { RenderWrapper } from 'test-utility/marker-renderer'
 
 describe('TimelineMarkers', () => {
@@ -22,5 +23,28 @@ describe('TimelineMarkers', () => {
         <TimelineMarkers />
       </RenderWrapper>
     )
+  })
+
+  it('is unsubscribed on unmounting after passing new date then hide it', ()=>{
+    const defaultCustomMarkerTestId = 'default-customer-marker-id'
+    const { queryByTestId, rerender } = render(
+      <RenderWrapper>
+        <TimelineMarkers>
+          <CustomMarker date={1000} />
+        </TimelineMarkers>
+      </RenderWrapper>)
+
+    rerender(<RenderWrapper>
+      <TimelineMarkers>
+        <CustomMarker date={2000} />
+      </TimelineMarkers>
+    </RenderWrapper>)
+
+    rerender(<RenderWrapper>
+      <TimelineMarkers>
+      </TimelineMarkers>
+    </RenderWrapper>)
+
+    expect(queryByTestId(defaultCustomMarkerTestId)).not.toBeInTheDocument()
   })
 })

--- a/src/lib/markers/TimelineMarkersContext.js
+++ b/src/lib/markers/TimelineMarkersContext.js
@@ -42,7 +42,7 @@ export class TimelineMarkersProvider extends React.Component {
       unsubscribe: () => {
         this.setState(state => {
           return {
-            markers: state.markers.filter(marker => marker !== newMarker)
+            markers: state.markers.filter(marker => marker.id !== newMarker.id)
           }
         })
       },


### PR DESCRIPTION
**524**

[Markers don't get unsubscribed after being hidden, if date has previously changed](https://github.com/namespace-ee/react-calendar-timeline/issues/524)

**Overview of PR**

Filtering Markers by Id instead of just the whole object, as if you change the marker date couple times, the marker won't be the same object on unsubscribe.

**Demo **

Before

![cusrommarker - before](https://user-images.githubusercontent.com/27180527/53520833-57eaad80-3ab5-11e9-9533-156511acc55d.gif)

After

![custommarker - after](https://user-images.githubusercontent.com/27180527/53520840-5de08e80-3ab5-11e9-878d-5ae7526c9bbe.gif)
