### PR TITLE
left align header when no left sidebar header content

### DIFF
--- a/src/lib/Timeline.scss
+++ b/src/lib/Timeline.scss
@@ -69,6 +69,10 @@ $weekend: rgba(250, 246, 225, 0.5);
       position: sticky;
       position: -webkit-sticky;
     }
+
+    .rct-header-elements-container{
+      position: relative;
+    }
   }
 
   .rct-header {

--- a/src/lib/layout/Header.js
+++ b/src/lib/layout/Header.js
@@ -56,6 +56,11 @@ class Header extends Component {
 
     const headerClass = stickyHeader ? 'header-sticky' : ''
 
+    const elementsHeaderContainerStyle = {
+      width,
+      ...(!leftSidebarHeader && {left: `${leftSidebarWidth}px`})
+    }
+
     const leftSidebar = leftSidebarHeader && leftSidebarWidth > 0 && (
       <div
         className="rct-sidebar-header"
@@ -82,7 +87,7 @@ class Header extends Component {
         style={headerStyle}
       >
         {leftSidebar}
-        <div style={{ width }} data-testid="timeline-elements-header-container">
+        <div style={elementsHeaderContainerStyle} className={`rct-header-elements-container`} data-testid="timeline-elements-header-container">
           <TimelineElementsHeader
             data-testid="timeline-elements-header"
             hasRightSidebar={hasRightSidebar}

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -7,7 +7,6 @@ class ScrollElement extends Component {
     children: PropTypes.element.isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
-    traditionalZoom: PropTypes.bool.isRequired,
     scrollRef: PropTypes.func.isRequired,
     isInteractingWithItem: PropTypes.bool.isRequired,
     onZoom: PropTypes.func.isRequired,
@@ -33,10 +32,6 @@ class ScrollElement extends Component {
   }
 
   handleWheel = e => {
-    const { traditionalZoom } = this.props
-
-    
-
     // zoom in the time dimension
     if (e.ctrlKey || e.metaKey || e.altKey) {
       e.preventDefault()


### PR DESCRIPTION
**Issue Number**

No issue exists. When not providing `sidebarContent` the header alignment messed up and floats to the left.

**Overview of PR**

* Align left the timeline elements header when leftSidebarHeader is absent.
* Fixed lint error. (traditionalZoom prop unused in ScrollElement.js)