### PR TITLE
build: add "test:coverage" script which will fail if coverage drops

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepublish": "npm run build:lib",
     "start": "webpack-dev-server --hot --host 0.0.0.0 --display-modules",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "files": [
     "lib",
@@ -76,6 +77,14 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"
     ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 61,
+        "branches": 42,
+        "functions": 71,
+        "lines": 61
+      }
+    },
     "modulePaths": [
       "<rootDir>/src/",
       "<rootDir>/__tests__"


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/426

**Overview of PR**

I saw that @acemac's issue and thought that it would be great if we include a script to run jest in coverage mode. In this way, you can also execute `npm run test:coverage` on each Travis PR build, so that any new code does not decrease the coverage.

For now, I've added the current coverage as the threshold but over time as we add more tests, this can be increased.

**Changelog**
As this PR only focuses on the build I assume a CHANGELOG.md update is not needed, but happy to add something if you like?
