### PR TITLE
build: use parser "babel" when running prettier-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:demo": "echo '!!! Building Demo' && cross-env NODE_ENV=production webpack --progress",
     "build:lib": "echo '!!! Building Library' && rimraf lib && cross-env NODE_ENV=production babel src --out-dir lib && node-sass src/lib/Timeline.scss lib/Timeline.css && sed -i'.bak' 's/Timeline\\.scss/Timeline\\.css/g' lib/lib/Timeline.js && rm lib/lib/Timeline.js.bak",
     "lint": "eslint --ext .js --ext .jsx ./src",
-    "lint:fix": "prettier-eslint --parser babylon --write \"src/**/*.js\"",
+    "lint:fix": "prettier-eslint --parser babel --write \"src/**/*.js\"",
     "prepublish": "npm run build:lib",
     "start": "webpack-dev-server --hot --host 0.0.0.0 --display-modules",
     "test": "jest",


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/556

**Overview of PR**

This fixes the following issue when running `npm run lint:fix`

```
> prettier-eslint --parser babylon --write "src/**/*.js"

{ parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.
```