### PR TITLE
Undefined classnames in TimelineHeaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+## 0.25.3
+
+- Fixed the `undefined` classnames in TimelineHeaders #566 @trevdor
+
 ## 0.25.2
 
 - Fixed the auto-scroll right bug in a scaled browser. #528 @cw196

--- a/__tests__/components/Headers/TimelineHeader.test.js
+++ b/__tests__/components/Headers/TimelineHeader.test.js
@@ -68,11 +68,25 @@ describe('TimelineHeader', () => {
     expect(getByTestId('headerContainer')).toHaveClass('testClassName')
   })
 
+  it('Given TimelineHeader When no calendarHeaderClassName specified Then undefined should not be applied to the date header container', () => {
+    const { getByTestId } = renderTimelineWithLeftAndRightSidebar({
+      calendarHeaderClassName: undefined
+    })
+    expect(getByTestId('headerContainer')).not.toHaveClass('undefined')
+  })
+
   it('Given TimelineHeader When pass className Then it should be applied to the root header container', () => {
     const { getByTestId } = renderTimelineWithLeftAndRightSidebar({
       className: 'testClassName'
     })
     expect(getByTestId('headerRootDiv')).toHaveClass('testClassName')
+  })
+
+  it('Given TimelineHeader When no className specified Then undefined should not be applied to the root header container', () => {
+    const { getByTestId } = renderTimelineWithLeftAndRightSidebar({
+      className: undefined
+    })
+    expect(getByTestId('headerRootDiv')).not.toHaveClass('undefined')
   })
 
   it('Given TimelineHeader When rendered Then it should render the default styles of the date header container', () => {
@@ -116,15 +130,16 @@ describe('TimelineHeader', () => {
     expect(getAllByTestId('sidebarHeader')).toHaveLength(1)
   })
   it('Given SidebarHeader When passing variant prop with right value Then it should rendered above the right sidebar', () => {
-    const { getByTestId, getAllByTestId, debug } = renderSidebarHeaderWithCustomValues(
-      { variant: 'right' }
-    )
+    const {
+      getByTestId,
+      getAllByTestId,
+      debug
+    } = renderSidebarHeaderWithCustomValues({ variant: 'right' })
     expect(getByTestId('sidebarHeader')).toBeInTheDocument()
     expect(getAllByTestId('sidebarHeader')).toHaveLength(2)
-    expect(getAllByTestId('sidebarHeader')[1].previousElementSibling).toHaveAttribute(
-      'data-testid',
-      'headerContainer'
-    )
+    expect(
+      getAllByTestId('sidebarHeader')[1].previousElementSibling
+    ).toHaveAttribute('data-testid', 'headerContainer')
   })
 
   it('Given SidebarHeader When passing variant prop with unusual value Then it should rendered above the left sidebar by default', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "^6.5.0",
+    "classnames": "^2.2.6",
     "cross-env": "^5.1.4",
     "css-loader": "~0.26.0",
     "enzyme": "^3.3.0",

--- a/src/lib/headers/TimelineHeaders.js
+++ b/src/lib/headers/TimelineHeaders.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import classNames from 'classnames';
+import classNames from 'classnames'
 import { TimelineHeadersConsumer } from './HeadersContext'
 import PropTypes from 'prop-types'
 import SidebarHeader from './SidebarHeader'
@@ -14,7 +14,7 @@ class TimelineHeaders extends React.Component {
     className: PropTypes.string,
     calendarHeaderStyle: PropTypes.object,
     calendarHeaderClassName: PropTypes.string,
-    headerRef: PropTypes.func,
+    headerRef: PropTypes.func
   }
 
   constructor(props) {
@@ -42,8 +42,8 @@ class TimelineHeaders extends React.Component {
     }
   }
 
-  handleRootRef = (element) => {
-    if(this.props.headerRef){
+  handleRootRef = element => {
+    if (this.props.headerRef) {
       this.props.headerRef(element)
     }
   }
@@ -66,11 +66,11 @@ class TimelineHeaders extends React.Component {
         calendarHeaders.push(child)
       }
     })
-    if(!leftSidebarHeader){
-      leftSidebarHeader= <SidebarHeader/>
+    if (!leftSidebarHeader) {
+      leftSidebarHeader = <SidebarHeader />
     }
-    if(!rightSidebarHeader && this.props.rightSidebarWidth){
-      rightSidebarHeader = <SidebarHeader variant="right"/>
+    if (!rightSidebarHeader && this.props.rightSidebarWidth) {
+      rightSidebarHeader = <SidebarHeader variant="right" />
     }
     return (
       <div
@@ -128,7 +128,7 @@ TimelineHeadersWrapper.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   calendarHeaderStyle: PropTypes.object,
-  calendarHeaderClassName: PropTypes.string,
+  calendarHeaderClassName: PropTypes.string
 }
 
 export default TimelineHeadersWrapper

--- a/src/lib/headers/TimelineHeaders.js
+++ b/src/lib/headers/TimelineHeaders.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import classNames from 'classnames';
 import { TimelineHeadersConsumer } from './HeadersContext'
 import PropTypes from 'prop-types'
 import SidebarHeader from './SidebarHeader'
@@ -75,13 +76,16 @@ class TimelineHeaders extends React.Component {
         ref={this.handleRootRef}
         data-testid="headerRootDiv"
         style={this.getRootStyle()}
-        className={`rct-header-root ${this.props.className}`}
+        className={classNames('rct-header-root', this.props.className)}
       >
         {leftSidebarHeader}
         <div
           ref={this.props.registerScroll}
           style={this.getCalendarHeaderStyle()}
-          className={`rct-calendar-header ${this.props.calendarHeaderClassName}`}
+          className={classNames(
+            'rct-calendar-header',
+            this.props.calendarHeaderClassName
+          )}
           data-testid="headerContainer"
         >
           {calendarHeaders}

--- a/src/lib/headers/TimelineHeaders.js
+++ b/src/lib/headers/TimelineHeaders.js
@@ -3,13 +3,14 @@ import classNames from 'classnames';
 import { TimelineHeadersConsumer } from './HeadersContext'
 import PropTypes from 'prop-types'
 import SidebarHeader from './SidebarHeader'
-import { RIGHT_VARIANT, LEFT_VARIANT } from './constants'
+import { RIGHT_VARIANT } from './constants'
 class TimelineHeaders extends React.Component {
   static propTypes = {
     registerScroll: PropTypes.func.isRequired,
     leftSidebarWidth: PropTypes.number.isRequired,
     rightSidebarWidth: PropTypes.number.isRequired,
     style: PropTypes.object,
+    children: PropTypes.node,
     className: PropTypes.string,
     calendarHeaderStyle: PropTypes.object,
     calendarHeaderClassName: PropTypes.string,
@@ -110,12 +111,13 @@ const TimelineHeadersWrapper = ({
           leftSidebarWidth={leftSidebarWidth}
           rightSidebarWidth={rightSidebarWidth}
           registerScroll={registerScroll}
-          children={children}
           style={style}
           className={className}
           calendarHeaderStyle={calendarHeaderStyle}
           calendarHeaderClassName={calendarHeaderClassName}
-        />
+        >
+          {children}
+        </TimelineHeaders>
       )
     }}
   </TimelineHeadersConsumer>
@@ -123,10 +125,10 @@ const TimelineHeadersWrapper = ({
 
 TimelineHeadersWrapper.propTypes = {
   style: PropTypes.object,
+  children: PropTypes.node,
   className: PropTypes.string,
   calendarHeaderStyle: PropTypes.object,
   calendarHeaderClassName: PropTypes.string,
-  headerRef: PropTypes.func,
 }
 
 export default TimelineHeadersWrapper


### PR DESCRIPTION
**Issue Number**

566

**Overview of PR**

Use [`classnames` utility](https://github.com/JedWatson/classnames) to build lists of classnames, automatically excluding falsey values.

Result:
![no_undefined_classnames](https://user-images.githubusercontent.com/5862724/59307957-fc57c080-8c5c-11e9-9ec2-1b64ece62a77.png)


Commits were separated for clarity but are intended to be squashed into one.

**Alternative Approach**
If the project does not want the new dependency on `classnames`, we could achieve the same exclusion of falsey values using just native JS, something like:
```jsx
const classnames = (...names) => names.filter(Boolean).join(" ");
className={classnames('rct-header-root', this.props.className)}

```
(Actually, after I write that out, I may like it better since the `classnames` package does a lot this project probably doesn't need. Happy to change it.)
