### PR TITLE
fix: classnames should be a prod dependency, not dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+## 0.25.4
+
+- Move `classnames` to a production dependency
+
 ## 0.25.3
 
 - Fixed the `undefined` classnames in TimelineHeaders #566 @trevdor

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     ]
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "create-react-context": "^0.2.2",
     "element-resize-detector": "^1.1.12",
     "lodash.isequal": "^4.5.0"
@@ -112,7 +113,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "^6.5.0",
-    "classnames": "^2.2.6",
     "cross-env": "^5.1.4",
     "css-loader": "~0.26.0",
     "enzyme": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,6 +1661,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"


### PR DESCRIPTION
Issue #598 

**Overview of PR**

Moves `classnames` to a production dependency

