### PR TITLE
Add onDragRenderer prop to <Timeline />

### DIFF
--- a/demo/app/demo-on-drag-renderer/CustomInfoLabel.js
+++ b/demo/app/demo-on-drag-renderer/CustomInfoLabel.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+
+export default function CustomInfoLabel(props) {
+  const { time, groupTitle } = props
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '100px',
+        left: '100px',
+        backgroundColor: '#E3F1DF',
+        color: '#212B36',
+        padding: '6px 12px',
+        fontSize: '16px',
+        borderRadius: '8px',
+        boxShadow:
+          '0 1px 3px rgba(0, 0, 0, 0.2), 0 10px 20px rgba(0, 0, 0, 0.05)'
+      }}
+    >
+      <div
+        style={{
+          fontWeight: 'bold',
+          borderBottom: '1px solid #ccc',
+          paddingBottom: '3px',
+          marginBottom: '3px'
+        }}
+      >
+        🚚 Moving to <span>{groupTitle}</span>
+      </div>
+      {moment(time).format('dddd, MMMM Do YYYY')}
+    </div>
+  )
+}
+
+CustomInfoLabel.propTypes = {
+  time: PropTypes.number,
+  groupTitle: PropTypes.string
+}

--- a/demo/app/demo-on-drag-renderer/index.js
+++ b/demo/app/demo-on-drag-renderer/index.js
@@ -1,0 +1,117 @@
+import React, { Component } from 'react'
+import moment from 'moment'
+
+import Timeline from 'react-calendar-timeline'
+import CustomInfoLabel from './CustomInfoLabel'
+
+import generateFakeData from '../generate-fake-data'
+
+var keys = {
+  groupIdKey: 'id',
+  groupTitleKey: 'title',
+  groupRightTitleKey: 'rightTitle',
+  itemIdKey: 'id',
+  itemTitleKey: 'title',
+  itemDivTitleKey: 'title',
+  itemGroupKey: 'group',
+  itemTimeStartKey: 'start',
+  itemTimeEndKey: 'end',
+  groupLabelKey: 'title'
+}
+
+export default class App extends Component {
+  constructor(props) {
+    super(props)
+
+    const { groups, items } = generateFakeData(5, 20)
+    const defaultTimeStart = moment()
+      .startOf('day')
+      .toDate()
+    const defaultTimeEnd = moment()
+      .startOf('day')
+      .add(1, 'day')
+      .toDate()
+
+    this.state = {
+      groups,
+      items,
+      defaultTimeStart,
+      defaultTimeEnd
+    }
+  }
+
+  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+    const { items, groups } = this.state
+
+    const group = groups[newGroupOrder]
+
+    this.setState({
+      items: items.map(
+        item =>
+          item.id === itemId
+            ? Object.assign({}, item, {
+                start: dragTime,
+                end: dragTime + (item.end - item.start),
+                group: group.id
+              })
+            : item
+      )
+    })
+  }
+
+  handleItemResize = (itemId, time, edge) => {
+    const { items } = this.state
+
+    this.setState({
+      items: items.map(
+        item =>
+          item.id === itemId
+            ? Object.assign({}, item, {
+                start: edge === 'left' ? time : item.start,
+                end: edge === 'left' ? item.end : time
+              })
+            : item
+      )
+    })
+  }
+
+  dragRenderer = ({
+    eventType,
+    InfoLabel,
+    dragTime,
+    dragGroupTitle,
+    resizeTime
+  }) => {
+    switch (eventType) {
+      case 'resize':
+        return <InfoLabel label={moment(resizeTime).format('ll')} />
+      case 'move':
+        return <CustomInfoLabel time={dragTime} groupTitle={dragGroupTitle} />
+      default:
+        return null
+    }
+  }
+
+  render() {
+    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+
+    return (
+      <Timeline
+        groups={groups}
+        items={items}
+        keys={keys}
+        fullUpdate
+        itemTouchSendsClick={false}
+        stackItems
+        itemHeightRatio={0.75}
+        canMove={true}
+        canResize={'both'}
+        defaultTimeStart={defaultTimeStart}
+        defaultTimeEnd={defaultTimeEnd}
+        onItemMove={this.handleItemMove}
+        onItemResize={this.handleItemResize}
+        onDragRenderer={this.dragRenderer}
+      />
+    )
+  }
+}

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -15,6 +15,7 @@ const demos = {
   verticalClasses: require('./demo-vertical-classes').default,
   customItems: require('./demo-custom-items').default,
   customHeaders: require('./demo-headers').default,
+  onDragRenderer: require('./demo-on-drag-renderer').default
 }
 
 // A simple component that shows the pathname of the current location

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -19,7 +19,7 @@ import {
   calculateScrollCanvas,
   getCanvasBoundariesFromVisibleTime,
   getCanvasWidth,
-  stackTimelineItems,
+  stackTimelineItems
 } from './utility/calendar'
 import { _get, _length } from './utility/generic'
 import {
@@ -77,6 +77,7 @@ export default class ReactCalendarTimeline extends Component {
     onCanvasDoubleClick: PropTypes.func,
     onCanvasContextMenu: PropTypes.func,
     onZoom: PropTypes.func,
+    onDragRenderer: PropTypes.func,
 
     moveResizeValidator: PropTypes.func,
 
@@ -195,6 +196,9 @@ export default class ReactCalendarTimeline extends Component {
     onItemDoubleClick: null,
     onItemContextMenu: null,
     onZoom: null,
+    onDragRenderer: ({ label, InfoLabel }) => {
+      return <InfoLabel label={label} />
+    },
 
     verticalLineClassNamesForTime: null,
 
@@ -252,7 +256,7 @@ export default class ReactCalendarTimeline extends Component {
       visibleTimeStart,
       visibleTimeEnd,
       canvasTimeStart,
-      canvasTimeEnd,
+      canvasTimeEnd
     } = this.state
 
     return {
@@ -283,7 +287,10 @@ export default class ReactCalendarTimeline extends Component {
       )
     }
 
-    const [canvasTimeStart, canvasTimeEnd] = getCanvasBoundariesFromVisibleTime(visibleTimeStart, visibleTimeEnd)
+    const [canvasTimeStart, canvasTimeEnd] = getCanvasBoundariesFromVisibleTime(
+      visibleTimeStart,
+      visibleTimeEnd
+    )
 
     this.state = {
       width: 1000,
@@ -299,24 +306,29 @@ export default class ReactCalendarTimeline extends Component {
       resizingEdge: null
     }
 
-    const canvasWidth=  getCanvasWidth(this.state.width)
+    const canvasWidth = getCanvasWidth(this.state.width)
 
-    const { dimensionItems, height, groupHeights, groupTops } = stackTimelineItems(
-        props.items,
-        props.groups,
-        canvasWidth,
-        this.state.canvasTimeStart,
-        this.state.canvasTimeEnd,
-        props.keys,
-        props.lineHeight,
-        props.itemHeightRatio,
-        props.stackItems,
-        this.state.draggingItem,
-        this.state.resizingItem,
-        this.state.dragTime,
-        this.state.resizingEdge,
-        this.state.resizeTime,
-        this.state.newGroupOrder
+    const {
+      dimensionItems,
+      height,
+      groupHeights,
+      groupTops
+    } = stackTimelineItems(
+      props.items,
+      props.groups,
+      canvasWidth,
+      this.state.canvasTimeStart,
+      this.state.canvasTimeEnd,
+      props.keys,
+      props.lineHeight,
+      props.itemHeightRatio,
+      props.stackItems,
+      this.state.draggingItem,
+      this.state.resizingItem,
+      this.state.dragTime,
+      this.state.resizingEdge,
+      this.state.resizeTime,
+      this.state.newGroupOrder
     )
 
     /* eslint-disable react/no-direct-mutation-state */
@@ -376,7 +388,8 @@ export default class ReactCalendarTimeline extends Component {
     } else if (forceUpdate) {
       // Calculate new item stack position as canvas may have changed
       const canvasWidth = getCanvasWidth(prevState.width)
-      Object.assign(derivedState, 
+      Object.assign(
+        derivedState,
         stackTimelineItems(
           items,
           groups,
@@ -393,7 +406,8 @@ export default class ReactCalendarTimeline extends Component {
           prevState.resizingEdge,
           prevState.resizeTime,
           prevState.newGroupOrder
-        ))
+        )
+      )
     }
 
     return derivedState
@@ -421,25 +435,28 @@ export default class ReactCalendarTimeline extends Component {
 
     // Check the scroll is correct
     const scrollLeft = Math.round(
-      (this.state.width *
-        (this.state.visibleTimeStart - this.state.canvasTimeStart)) /
+      this.state.width *
+        (this.state.visibleTimeStart - this.state.canvasTimeStart) /
         newZoom
     )
-    const componentScrollLeft = Math.round(this.scrollComponent.scrollLeft);
+    const componentScrollLeft = Math.round(this.scrollComponent.scrollLeft)
     if (componentScrollLeft !== scrollLeft) {
-      this.scrollComponent.scrollLeft = scrollLeft;
-      this.scrollHeaderRef.scrollLeft = scrollLeft;
+      this.scrollComponent.scrollLeft = scrollLeft
+      this.scrollHeaderRef.scrollLeft = scrollLeft
     }
   }
 
   resize = (props = this.props) => {
-    const {
-      width: containerWidth,
-    } = this.container.getBoundingClientRect()
+    const { width: containerWidth } = this.container.getBoundingClientRect()
 
     let width = containerWidth - props.sidebarWidth - props.rightSidebarWidth
     const canvasWidth = getCanvasWidth(width)
-    const { dimensionItems, height, groupHeights, groupTops } = stackTimelineItems(
+    const {
+      dimensionItems,
+      height,
+      groupHeights,
+      groupTops
+    } = stackTimelineItems(
       props.items,
       props.groups,
       canvasWidth,
@@ -465,7 +482,7 @@ export default class ReactCalendarTimeline extends Component {
       dimensionItems,
       height,
       groupHeights,
-      groupTops,
+      groupTops
     })
 
     this.scrollComponent.scrollLeft = width
@@ -491,7 +508,7 @@ export default class ReactCalendarTimeline extends Component {
 
     const zoom = this.state.visibleTimeEnd - this.state.visibleTimeStart
 
-    const visibleTimeStart = canvasTimeStart + (zoom * scrollX) / width
+    const visibleTimeStart = canvasTimeStart + zoom * scrollX / width
 
     if (
       this.state.visibleTimeStart !== visibleTimeStart ||
@@ -527,7 +544,7 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   handleWheelZoom = (speed, xPosition, deltaY) => {
-    this.changeZoom(1.0 + (speed * deltaY) / 500, xPosition / this.state.width)
+    this.changeZoom(1.0 + speed * deltaY / 500, xPosition / this.state.width)
   }
 
   changeZoom = (scale, offset = 0.5) => {
@@ -604,18 +621,14 @@ export default class ReactCalendarTimeline extends Component {
   // as well as generalizing how we get time from click on the canvas
   getTimeFromRowClickEvent = e => {
     const { dragSnap } = this.props
-    const {
-      width,
-      canvasTimeStart,
-      canvasTimeEnd,
-    } = this.state
+    const { width, canvasTimeStart, canvasTimeEnd } = this.state
     // this gives us distance from left of row element, so event is in
     // context of the row element, not client or page
     const { offsetX } = e.nativeEvent
 
     let time = calculateTimeForXPosition(
       canvasTimeStart,
-      
+
       canvasTimeEnd,
       getCanvasWidth(width),
       offsetX
@@ -806,15 +819,28 @@ export default class ReactCalendarTimeline extends Component {
 
   infoLabel() {
     let label = null
+    let eventType = ''
+    const { dragTime, dragGroupTitle, resizeTime } = this.state
 
-    if (this.state.dragTime) {
-      label = `${moment(this.state.dragTime).format('LLL')}, 
-        ${this.state.dragGroupTitle}`
-    } else if (this.state.resizeTime) {
-      label = moment(this.state.resizeTime).format('LLL')
+    if (dragTime) {
+      eventType = 'move'
+      label = `${moment(dragTime).format('LLL')},
+        ${dragGroupTitle}`
+    } else if (resizeTime) {
+      eventType = 'resize'
+      label = moment(resizeTime).format('LLL')
     }
 
-    return label ? <InfoLabel label={label} /> : undefined
+    return label
+      ? this.props.onDragRenderer({
+          eventType,
+          dragTime,
+          dragGroupTitle,
+          resizeTime,
+          label,
+          InfoLabel
+        })
+      : undefined
   }
 
   handleHeaderRef = el => {
@@ -825,33 +851,33 @@ export default class ReactCalendarTimeline extends Component {
   sidebar(height, groupHeights) {
     const { sidebarWidth } = this.props
     return (
-      sidebarWidth && 
-      <Sidebar
-        groups={this.props.groups}
-        groupRenderer={this.props.groupRenderer}
-        keys={this.props.keys}
-        width={sidebarWidth}
-        groupHeights={groupHeights}
-        height={height}
-
-      />
+      sidebarWidth && (
+        <Sidebar
+          groups={this.props.groups}
+          groupRenderer={this.props.groupRenderer}
+          keys={this.props.keys}
+          width={sidebarWidth}
+          groupHeights={groupHeights}
+          height={height}
+        />
+      )
     )
   }
 
   rightSidebar(height, groupHeights) {
     const { rightSidebarWidth } = this.props
     return (
-      rightSidebarWidth &&
-      <Sidebar
-        groups={this.props.groups}
-        keys={this.props.keys}
-        groupRenderer={this.props.groupRenderer}
-        isRightSidebar
-        width={rightSidebarWidth}
-        groupHeights={groupHeights}
-        height={height}
-
-      />
+      rightSidebarWidth && (
+        <Sidebar
+          groups={this.props.groups}
+          keys={this.props.keys}
+          groupRenderer={this.props.groupRenderer}
+          isRightSidebar
+          width={rightSidebarWidth}
+          groupHeights={groupHeights}
+          height={height}
+        />
+      )
     )
   }
 
@@ -949,7 +975,7 @@ export default class ReactCalendarTimeline extends Component {
       visibleTimeStart,
       visibleTimeEnd,
       canvasTimeStart,
-      canvasTimeEnd,
+      canvasTimeEnd
     } = this.state
     let { dimensionItems, height, groupHeights, groupTops } = this.state
 
@@ -1040,7 +1066,7 @@ export default class ReactCalendarTimeline extends Component {
                       canvasWidth,
                       minUnit,
                       timeSteps,
-                      height,
+                      height
                     )}
                     {this.rows(canvasWidth, groupHeights, groups)}
                     {this.infoLabel()}


### PR DESCRIPTION
## Issue Number
#517 

## Overview of PR
⚠️ Closing this PR in favour of #612

### 🤔 Considerations
I read through the thread between @Ilaiwi & @FutureArchitect-wang2449. I know @Ilaiwi had advised removing the `<InfoLabel />` altogether, I ultimately felt a bit reticent to introduce a breaking change for current users of this library. The properties tagged with ⭐️ were left in to ensure backwards-compatibility for users who are happy with the current behaviour.

### 🧪 Testing
I looked through your test suite, I wasn't sure how to go about testing this. Open to suggestions!

### What was added
- Expose `onDragRenderer` prop on `<Timeline />`
  - `onDragRenderer` expects a function that returns a React Element
  - `onDragRenderer` provides an object with the following values:
    - 1️⃣ `eventType`: a String value of either `move` or `resize`
    - 2️⃣ `dragTime`: on a `move` event, the time an Item is being moved to
    - 3️⃣ `dragGroupTitle`: on a `move` event, the name of the new group
    - 4️⃣ `resizeTime`: on a `resize` event, the time an Item is being resized to
    - 5️⃣ ⭐️  `label`: the Moment-formatted time (`LLL`), includes the `dragGroupTitle` on the move event
    - 6️⃣ ⭐️ `InfoLabel`: the `<InfoLabel />` component


### 👀 Demo Example
A demo example has been included. This example renders the `<InfoLabel />` on the `resize` event and a `<CustomInfoLabel />` on the `move` event.

![onDragRenderer Example](https://screenshot.click/2019-18-02-cxcql-l20qx.gif)

### 📝 Other Notes
I haven't updated the `CHANGELOG.md` yet. I'll get that up tomorrow. Just wanted to start a conversation with you around this and get your eyes on the PR 😊 .

_Don't forget to update the CHANGELOG.md file with any changes that are in this PR_
