### PR TITLE
Fixing row height on browser scaling

### DIFF
--- a/__tests__/components/GroupRow/GroupRows.test.js
+++ b/__tests__/components/GroupRow/GroupRows.test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { noop } from 'test-utility'
+import GroupRows from 'lib/row/GroupRows'
+
+const defaultProps = {
+  groups: [
+    {
+        bgColor: '#e8ccff',
+        id: '2998',
+        label: 'Label Dustin"',
+        rightTitle: 'Wolff',
+        title: 'Carlotta',
+    },
+    {
+        bgColor: '#e8ccff',
+        id: '2999',
+        label: 'Label Myrtle"',
+        rightTitle: '"Sauer"',
+        title: 'Elmer',
+    }
+  ],
+  canvasWidth: 10,
+  lineCount: 2,
+  groupHeights: [30, 27],
+  onRowClick: noop,
+  onRowDoubleClick: noop,
+  clickTolerance: 0,
+  onRowContextClick: noop,
+}
+
+describe('GroupRows', () => {
+  it('passes props and get right height for first group', () => {
+    const wrapper = mount(<GroupRows {...defaultProps} />);
+
+    const component = wrapper.find('GroupRow').first();
+    expect(component.prop('style').height).toBe('30px');
+  })
+})

--- a/__tests__/components/Sidebar/Sidebar.test.js
+++ b/__tests__/components/Sidebar/Sidebar.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import Sidebar from 'lib/layout/Sidebar'
+
+const defaultProps = {
+  groups: [
+    {
+        bgColor: '#e8ccff',
+        id: '2998',
+        label: 'Label Dustin"',
+        rightTitle: 'Wolff',
+        title: 'Carlotta',
+    },
+    {
+        bgColor: '#e8ccff',
+        id: '2999',
+        label: 'Label Myrtle"',
+        rightTitle: '"Sauer"',
+        title: 'Elmer',
+    }
+  ],
+  width: 10,
+  height: 10,
+  groupHeights: [30, 27],
+  keys: {
+    groupIdKey: 'id',
+    groupRightTitleKey: 'rightTitle',
+    groupTitleKey: 'title',
+    itemDivTitleKey: 'title',
+    itemGroupKey: 'group',
+    itemIdKey: 'id',
+    itemTimeEndKey: 'end',
+    itemTimeStartKey: 'start',
+    itemTitleKey: 'title'
+  }
+}
+
+describe('GroupRows', () => {
+  it('passes props and get right height for first group', () => {
+    const wrapper = mount(<Sidebar {...defaultProps} />);
+
+    const component = wrapper.find('div.rct-sidebar-row').first();
+    expect(component.prop('style').height).toBe('30px');
+  })
+})

--- a/src/lib/Timeline.scss
+++ b/src/lib/Timeline.scss
@@ -161,7 +161,7 @@ $weekend: rgba(250, 246, 225, 0.5);
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      box-sizing: content-box;
+      box-sizing: border-box;
       margin: 0;
       border-bottom: $border-width solid $border-color;
 
@@ -195,7 +195,7 @@ $weekend: rgba(250, 246, 225, 0.5);
     .rct-hl-even,
     .rct-hl-odd {
       border-bottom: $border-width solid $border-color;
-      box-sizing: content-box;
+      box-sizing: border-box;
       z-index: 40;
     }
     .rct-hl-odd {

--- a/src/lib/layout/Sidebar.js
+++ b/src/lib/layout/Sidebar.js
@@ -51,8 +51,8 @@ export default class Sidebar extends Component {
 
     let groupLines = this.props.groups.map((group, index) => {
       const elementStyle = {
-        height: `${groupHeights[index] - 1}px`,
-        lineHeight: `${groupHeights[index] - 1}px`
+        height: `${groupHeights[index]}px`,
+        lineHeight: `${groupHeights[index]}px`
       }
 
       return (

--- a/src/lib/row/GroupRows.js
+++ b/src/lib/row/GroupRows.js
@@ -51,7 +51,7 @@ export default class GroupRows extends Component {
           horizontalLineClassNamesForGroup={horizontalLineClassNamesForGroup}
           style={{
             width: `${canvasWidth}px`,
-            height: `${groupHeights[i] - 1}px`
+            height: `${groupHeights[i]}px`
           }}
         />
       )


### PR DESCRIPTION
**609**

[Items get misaligned from their row on browser scaling](https://github.com/namespace-ee/react-calendar-timeline/issues/609)

**Overview of PR**

Items get misaligned from their rows as the timeline gets scrolled down when the browser scale is different than 100%

This is happening because on some zoom levels, the row is `30px` height (default value), and for other % it gets to `29.98px`.

This undesired behaviour is fixable by replacing `content-box` by `border-box` for **box-sizing** property on `.rct-sidebar-row` and `.rct-horizontal-lines`.

Now, the subtraction of `1px` from the height in `GroupRow` and `Sidebar` components is no longer needed as the `border-bottom` is included in the element dimensions.

**Demo**

## Before 👎 

### Scrolling down

![misaligned-items-before](https://user-images.githubusercontent.com/27180527/60629933-f9ab4e00-9e4b-11e9-934b-c335e923e4c5.gif)

### Scrolled down and scaling 

![calendar-zoom-demo](https://user-images.githubusercontent.com/27180527/60629951-06c83d00-9e4c-11e9-88da-f12d3374cda8.gif)

### Row height on browser scaled drops to 29.98px

![Screen Shot 2019-07-04 at 10 26 27 AM](https://user-images.githubusercontent.com/27180527/60630963-fb2b4500-9e50-11e9-8f27-2d121463d38c.png)

## After 👍 

### Scrolling down

![misaligned-items-after](https://user-images.githubusercontent.com/27180527/60629961-0fb90e80-9e4c-11e9-8ac1-5a3d3af0ba65.gif)

### Scrolled down and scaling

![calendar-zoom-demo-after](https://user-images.githubusercontent.com/27180527/60630295-b0f49480-9e4d-11e9-9487-4d9303e7a91b.gif)

### Row height on browser scaled remains 30px

![Screen Shot 2019-07-04 at 2 48 11 PM](https://user-images.githubusercontent.com/27180527/60636511-d2b04480-9e6a-11e9-8ddb-0b339c497dc5.png)