### PR TITLE
Clarify stackItems option timestamp requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 # 0.26.4
 
 * fix `react-calendar-timeline` not working with `react-hot-loader` #607 @ilaiwi + @westn
+* add documentation for `stackItems` format #661 @tyson-kubota
 
 ## 0.26.3
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Append a special `.rct-drag-right` handle to the elements and only resize if dra
 
 ### stackItems
 
-Stack items under each other, so there is no visual overlap when times collide.  Can be overridden in the `groups` array. Defaults to `false`.
+Stack items under each other, so there is no visual overlap when times collide.  Can be overridden in the `groups` array. Defaults to `false`. Requires millisecond or `Moment` timestamps, not native JavaScript `Date` objects.
 
 ## traditionalZoom
 


### PR DESCRIPTION
**Issue Number**

https://github.com/namespace-ee/react-calendar-timeline/issues/473

**Overview of PR**

The `stackItems` option does nothing if the timeline objects use native JS Date objects. Instead, they must be milliseconds or Moment timestamps.

This PR updates the documentation to reflect the above.