### PR TITLE
Add unit argument to onZoom and onTimeChange callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+* Add unit argument to onZoom and onTimeChange callbacks
+
 ## 0.26.6
 
 * fix `visibleTimeStart`, `visibleTimeEnd` and `onTimeChange` not working as expected in controlled mode @ilaiwi
@@ -42,11 +44,11 @@ Using controlled scroll and react-spring to trigger scrolling and create an anim
 
 * add documentation for `onItemDeselect` #350 @ilaiwi
 * solve a bug where `onItemDeselect` is not triggered as expected for several item clicks #350 @ilaiwi
-* fix row height on browser scaling #615 @gaston-niglia 
+* fix row height on browser scaling #615 @gaston-niglia
 
 ### Packages
 
-update to `node-sass@4.12.0` for newer versions of node. 
+update to `node-sass@4.12.0` for newer versions of node.
 
 ## 0.26.2
 
@@ -78,7 +80,7 @@ you can as well solve the issue without upgrading by adding the following style
 
 #### Breaking
 
-* Removed `<InfoLabel />` in favour of allowing for custom component to be rendered on move or resize. Check out the demo in `demo/app/demo-custom-info-label` for an example on how to display your own custom info label or [this example](https://codesandbox.io/s/timeline-demo-info-label-neec9). 
+* Removed `<InfoLabel />` in favour of allowing for custom component to be rendered on move or resize. Check out the demo in `demo/app/demo-custom-info-label` for an example on how to display your own custom info label or [this example](https://codesandbox.io/s/timeline-demo-info-label-neec9).
 
 
 ## 0.25.4

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Called when an empty spot on the canvas was double clicked. Get the group and th
 
 Called when the canvas is clicked by the right button of the mouse. Note: If this property is set the default context menu doesn't appear
 
-## onZoom(timelineContext)
+## onZoom(timelineContext, unit)
 
 Called when the timeline is zoomed, either via mouse/pinch zoom or clicking header to change timeline units
 
@@ -338,7 +338,7 @@ function (action, item, time, resizeEdge) {
 ```
 
 
-## onTimeChange(visibleTimeStart, visibleTimeEnd, updateScrollCanvas)
+## onTimeChange(visibleTimeStart, visibleTimeEnd, updateScrollCanvas, unit)
 
 A function that's called when the user tries to scroll. Call the passed `updateScrollCanvas(start, end)` with the updated visibleTimeStart and visibleTimeEnd (as unix timestamps in milliseconds) to change the scroll behavior, for example to limit scrolling.
 

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -135,6 +135,10 @@ export default class App extends Component {
     }
   }
 
+  handleZoom = (timelineContext, unit) => {
+    console.log('Zoomed', timelineContext, unit)
+  }
+
   moveResizeValidator = (action, item, time) => {
     if (time < new Date().getTime()) {
       var newTime =
@@ -174,6 +178,7 @@ export default class App extends Component {
         onItemResize={this.handleItemResize}
         onItemDoubleClick={this.handleItemDoubleClick}
         onTimeChange={this.handleTimeChange}
+        onZoom={this.handleZoom}
         moveResizeValidator={this.moveResizeValidator}
       >
         <TimelineMarkers>

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -264,6 +264,21 @@ export default class ReactCalendarTimeline extends Component {
     }
   }
 
+  getTimelineUnit = () => {
+    const {
+      width,
+      visibleTimeStart,
+      visibleTimeEnd
+    } = this.state
+
+    const { timeSteps } = this.props
+
+    const zoom = visibleTimeEnd - visibleTimeStart
+    const minUnit = getMinUnit(zoom, width, timeSteps)
+
+    return minUnit
+  }
+
   constructor(props) {
     super(props)
 
@@ -409,7 +424,7 @@ export default class ReactCalendarTimeline extends Component {
         )
       )
     }
-    
+
     return derivedState
   }
 
@@ -419,7 +434,7 @@ export default class ReactCalendarTimeline extends Component {
 
     // are we changing zoom? Report it!
     if (this.props.onZoom && newZoom !== oldZoom) {
-      this.props.onZoom(this.getTimelineContext())
+      this.props.onZoom(this.getTimelineContext(), this.getTimelineUnit())
     }
 
     // The bounds have changed? Report it!
@@ -509,7 +524,8 @@ export default class ReactCalendarTimeline extends Component {
       this.props.onTimeChange(
         visibleTimeStart,
         visibleTimeStart + zoom,
-        this.updateScrollCanvas
+        this.updateScrollCanvas,
+        this.getTimelineUnit()
       )
     }
   }
@@ -553,7 +569,8 @@ export default class ReactCalendarTimeline extends Component {
     this.props.onTimeChange(
       newVisibleTimeStart,
       newVisibleTimeStart + newZoom,
-      this.updateScrollCanvas
+      this.updateScrollCanvas,
+      this.getTimelineUnit()
     )
   }
 
@@ -570,7 +587,8 @@ export default class ReactCalendarTimeline extends Component {
     this.props.onTimeChange(
       visibleTimeStart,
       visibleTimeStart + zoom,
-      this.updateScrollCanvas
+      this.updateScrollCanvas,
+      this.getTimelineUnit()
     )
   }
 
@@ -869,13 +887,13 @@ export default class ReactCalendarTimeline extends Component {
 
   /**
    * check if child of type TimelineHeader
-   * refer to for explanation https://github.com/gaearon/react-hot-loader#checking-element-types 
+   * refer to for explanation https://github.com/gaearon/react-hot-loader#checking-element-types
    */
   isTimelineHeader = (child) => {
     if(child.type === undefined) return false
     return child.type.secretKey ===TimelineHeaders.secretKey
   }
-  
+
   childrenWithProps(
     canvasTimeStart,
     canvasTimeEnd,


### PR DESCRIPTION
**Issue Number**

#655 

**Overview of PR**

I added `unit` argument to `onZoom` and `onTimeChange` callbacks,  as discussed in #655.
