### PR TITLE
Add className prop to top-level Timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+* Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
+
 ## 0.26.7
 
 * fix scrolling with trackpad @ilaiwi #679

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ An array specifying keys in the `items` and `groups` objects. Defaults to
 }
 ```
 
+## className
+
+Class name for the root Timeline element. Defaults to `react-calendar-timeline`.
+
 ## sidebarWidth
 
 Width of the sidebar in pixels. If set to `0`, the sidebar is not rendered. Defaults to `150`.
@@ -431,7 +435,8 @@ Rather than applying props on the element yourself and to avoid your props being
   * onTouchEnd: event handler
   * onDoubleClick: event handler
   * onContextMenu: event handler
-  * style: inline object style
+  * style: inline object 
+  
 
   \*\* _the given styles will only override the styles that are not a requirement for positioning the item. Other styles like `color`, `radius` and others_
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ An array specifying keys in the `items` and `groups` objects. Defaults to
 
 ## className
 
-Class name for the root Timeline element. Defaults to `react-calendar-timeline`.
+Additional class names as a string for the root Timeline element.
 
 ## sidebarWidth
 

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -209,7 +209,7 @@ export default class ReactCalendarTimeline extends Component {
     itemTouchSendsClick: false,
 
     style: {},
-    className: 'react-calendar-timeline',
+    className: '',
     keys: defaultKeys,
     timeSteps: defaultTimeSteps,
     headerRef: () => {},
@@ -1042,7 +1042,7 @@ export default class ReactCalendarTimeline extends Component {
             <div
               style={this.props.style}
               ref={el => (this.container = el)}
-              className={this.props.className}
+              className={`react-calendar-timeline ${this.props.className}`}
             >
               {this.renderHeaders()}
               <div style={outerComponentStyle} className="rct-outer">

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -82,6 +82,7 @@ export default class ReactCalendarTimeline extends Component {
     itemRenderer: PropTypes.func,
     groupRenderer: PropTypes.func,
 
+    className: PropTypes.string,
     style: PropTypes.object,
 
     keys: PropTypes.shape({
@@ -208,6 +209,7 @@ export default class ReactCalendarTimeline extends Component {
     itemTouchSendsClick: false,
 
     style: {},
+    className: 'react-calendar-timeline',
     keys: defaultKeys,
     timeSteps: defaultTimeSteps,
     headerRef: () => {},
@@ -1040,7 +1042,7 @@ export default class ReactCalendarTimeline extends Component {
             <div
               style={this.props.style}
               ref={el => (this.container = el)}
-              className="react-calendar-timeline"
+              className={this.props.className}
             >
               {this.renderHeaders()}
               <div style={outerComponentStyle} className="rct-outer">


### PR DESCRIPTION
**Issue Number**

Fixes #682.

**Overview of PR**

Adds a `className` prop to the top-level `Timeline` component to override the `react-calendar-timeline` class.
