### PR TITLE
check for offsetParent before using

### DIFF
--- a/src/lib/utility/dom-helpers.js
+++ b/src/lib/utility/dom-helpers.js
@@ -37,7 +37,7 @@ export function getSumScroll(node) {
 }
 
 export function getSumOffset(node) {
-  if (node === document.body) {
+  if (node === document.body || !node.offsetParent) {
     return {offsetLeft: 0, offsetTop: 0}
   } else {
     const parent = getSumOffset(node.offsetParent)


### PR DESCRIPTION
**Issue Number 703**

[issue](https://github.com/namespace-ee/react-calendar-timeline/issues/703)

**Overview of PR**

This Pr changes `getSumOffset` to stop recursing if offsetParent is null. This prevents crashes in cases where some ancestor has `position: fixed`
