### PR TITLE
fix start and end of day when there is daylight saving

### DIFF
--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -68,7 +68,7 @@ export function iterateTimes(start, end, unit, timeSteps, callback) {
   }
 
   while (time.valueOf() < end) {
-    let nextTime = moment(time).add(timeSteps[unit] || 1, `${unit}s`)
+    let nextTime = moment(time).add(timeSteps[unit] || 1, `${unit}s`).startOf(unit);
     callback(time, nextTime)
     time = nextTime
   }


### PR DESCRIPTION
**Overview of PR**

Issue:
Currently if there is a daylight saving, the days after the daylight saving starts at 1am.

Fix:
Always make sure when iterating that it start at the beginning of the day.