### PR TITLE
Fix injecting custom class names for vertical lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 ## Unreleased
 
 * Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
+* Fix injecting custom vertical line's class names for time periods longer than day
 
 ## 0.26.7
 

--- a/src/lib/columns/Columns.js
+++ b/src/lib/columns/Columns.js
@@ -73,7 +73,7 @@ class Columns extends Component {
           (firstOfType ? ' rct-vl-first' : '') +
           (minUnit === 'day' || minUnit === 'hour' || minUnit === 'minute'
             ? ` rct-day-${time.day()} `
-            : '') +
+            : ' ') +
           classNamesForTime.join(' ')
 
         const left = getLeftOffsetFromDate(time.valueOf())


### PR DESCRIPTION
Fixes injecting custom class names for vertical lines spanning over a period of time longer than day (eg. month)

Right now if we want to inject custom class name for vertical line spanning month it's class names end up corrupted. If I'll return `timeline-month` class from `verticalLineClassNamesForTime` function I'll end up with vertical line element: `<div class="rct-vltimeline-month">` instead of `<div class="rct-vl timeline-month">`
