### PR TITLE
fix controlled mode side scrolling via CSS, rm some unusued imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
-* Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
+- Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
+- Fix `visibleTimeStart`, `visibleTimeEnd` and `onTimeChange` scrolling behavior with trackpad and mouse side scrolling
 
 ## 0.26.7
 
-* fix scrolling with trackpad @ilaiwi #679
-* remove duplicate proptype validation in `TimelineStateContext` @xat
+- fix scrolling with trackpad @ilaiwi #679
+- remove duplicate proptype validation in `TimelineStateContext` @xat
 
 ## 0.26.6
 
-* fix `visibleTimeStart`, `visibleTimeEnd` and `onTimeChange` not working as expected in controlled mode @ilaiwi
+- fix `visibleTimeStart`, `visibleTimeEnd` and `onTimeChange` not working as expected in controlled mode @ilaiwi
 
 ### examples
 
@@ -36,32 +37,32 @@ Using controlled scroll and react-spring to trigger scrolling and create an anim
 
 ## 0.26.5
 
-* improve performance by:
+- improve performance by:
   - eliminate extra call of layout on state update @ilaiwi
   - eliminate unmounting and mounting of Interval Component @ilaiwi
 
 ## 0.26.4
 
-* fix `react-calendar-timeline` not working with `react-hot-loader` #607 @ilaiwi + @westn
-* add documentation for `stackItems` format #661 @tyson-kubota
+- fix `react-calendar-timeline` not working with `react-hot-loader` #607 @ilaiwi + @westn
+- add documentation for `stackItems` format #661 @tyson-kubota
 
 ## 0.26.3
 
-* add documentation for `onItemDeselect` #350 @ilaiwi
-* solve a bug where `onItemDeselect` is not triggered as expected for several item clicks #350 @ilaiwi
-* fix row height on browser scaling #615 @gaston-niglia 
+- add documentation for `onItemDeselect` #350 @ilaiwi
+- solve a bug where `onItemDeselect` is not triggered as expected for several item clicks #350 @ilaiwi
+- fix row height on browser scaling #615 @gaston-niglia
 
 ### Packages
 
-update to `node-sass@4.12.0` for newer versions of node. 
+update to `node-sass@4.12.0` for newer versions of node.
 
 ## 0.26.2
 
-* render the items layer after columns and rows for layring @ilaiwi
+- render the items layer after columns and rows for layring @ilaiwi
 
 ## 0.26.1
 
-* fix issue where mouse down gets stuck when scrolling the timeline #526 @KhalidArdah
+- fix issue where mouse down gets stuck when scrolling the timeline #526 @KhalidArdah
 
 you can as well solve the issue without upgrading by adding the following style
 
@@ -80,30 +81,29 @@ you can as well solve the issue without upgrading by adding the following style
 
 #### Added
 
-* Add `onItemDrag` prop to `<Timeline />` #517 @bettymakes
-* Upgrade to Babel 7.5.0, Jest 24.8.0, Enzyme 3.10.0 @trevdor
+- Add `onItemDrag` prop to `<Timeline />` #517 @bettymakes
+- Upgrade to Babel 7.5.0, Jest 24.8.0, Enzyme 3.10.0 @trevdor
 
 #### Breaking
 
-* Removed `<InfoLabel />` in favour of allowing for custom component to be rendered on move or resize. Check out the demo in `demo/app/demo-custom-info-label` for an example on how to display your own custom info label or [this example](https://codesandbox.io/s/timeline-demo-info-label-neec9). 
-
+- Removed `<InfoLabel />` in favour of allowing for custom component to be rendered on move or resize. Check out the demo in `demo/app/demo-custom-info-label` for an example on how to display your own custom info label or [this example](https://codesandbox.io/s/timeline-demo-info-label-neec9).
 
 ## 0.25.4
 
-* Move `classnames` to a production dependency
+- Move `classnames` to a production dependency
 
 ## 0.25.3
 
-* Fixed the `undefined` classnames in TimelineHeaders #566 @trevdor
+- Fixed the `undefined` classnames in TimelineHeaders #566 @trevdor
 
 ## 0.25.2
 
-* Fixed the auto-scroll right bug in a scaled browser. #528 @cw196
+- Fixed the auto-scroll right bug in a scaled browser. #528 @cw196
 
 ## 0.25.1
 
-* fix error when using `week` unit causing format error in `DateHeader` #562 @dkarnutsch
-* fix Wheel/Mousewheel Event errors on chrome 73 #541 @ilaiwi
+- fix error when using `week` unit causing format error in `DateHeader` #562 @dkarnutsch
+- fix Wheel/Mousewheel Event errors on chrome 73 #541 @ilaiwi
 
 ## 0.25.0
 
@@ -118,7 +118,7 @@ import Timeline, {
   DateHeader
 } from 'react-calendar-timeline'
 
-<Timeline>
+;<Timeline>
   <TimelineHeaders>
     <SidebarHeader>
       {({ getRootProps }) => {
@@ -127,13 +127,13 @@ import Timeline, {
     </SidebarHeader>
     <DateHeader unit="primaryHeader" />
     <DateHeader />
-    <CustomHeader height={50} headerData={{someData: 'data'}} unit="year">
+    <CustomHeader height={50} headerData={{ someData: 'data' }} unit="year">
       {({
         headerContext: { intervals },
         getRootProps,
         getIntervalProps,
         showPeriod,
-        data,
+        data
       }) => {
         return (
           <div {...getRootProps()}>
@@ -174,22 +174,22 @@ Check out the new docs before please [here](https://github.com/namespace-ee/reac
 
 #### removed props
 
-* `stickyOffset` and `stickyHeader` now you can make your header sticky by following this [examples](https://github.com/namespace-ee/react-calendar-timeline/tree/master/examples#custom-item-rendering)
-* `headerRef` to get the headerRef you need to pass ref callback to `TimelineHeader` component
-* `headerLabelGroupHeight` and `headerLabelHeight` now you can pass a `height` prop to both `CustomHeader` and `DateHeader`
-* `headerLabelFormats` and `subHeaderLabelFormats` not you can pass `formatLabel` function to `DateHeader` with label width and start and end time of intervals
+- `stickyOffset` and `stickyHeader` now you can make your header sticky by following this [examples](https://github.com/namespace-ee/react-calendar-timeline/tree/master/examples#custom-item-rendering)
+- `headerRef` to get the headerRef you need to pass ref callback to `TimelineHeader` component
+- `headerLabelGroupHeight` and `headerLabelHeight` now you can pass a `height` prop to both `CustomHeader` and `DateHeader`
+- `headerLabelFormats` and `subHeaderLabelFormats` not you can pass `formatLabel` function to `DateHeader` with label width and start and end time of intervals
 
 ## 0.23.1
 
-* fix height calculation of stacked items is off if no item is visible in a line @Felix-N
-* fix Unsubscribing markers correctly when unmounted @gaston-niglia
+- fix height calculation of stacked items is off if no item is visible in a line @Felix-N
+- fix Unsubscribing markers correctly when unmounted @gaston-niglia
 
 ## 0.23.0
 
-* improve unit tests coverage #426 - @ilaiwi
-* stack items by group #384 - @acemac
-* fix bug where `canMove` prop gets ignored #484 - @acemac + @ilaiwi
-* fix sidebar re-render when groupHeights do not change #478 - @SDupZ
+- improve unit tests coverage #426 - @ilaiwi
+- stack items by group #384 - @acemac
+- fix bug where `canMove` prop gets ignored #484 - @acemac + @ilaiwi
+- fix sidebar re-render when groupHeights do not change #478 - @SDupZ
 
 ### Stack per group
 
@@ -240,79 +240,79 @@ ReactDOM.render(
 
 ### Fixed
 
-* Provided a new key `groupLabelKey` to allow splitting of the key used to render the Sidebar and the InfoLabel visible during drag operations. `groupTitleKey` continues to be used to render the Sidebar. #442 @thiagosatoshi
-* fix scroll left/right causes item move/edit to be at incorrect time #401 @acemac
-* now `getResizeProps` take `leftClassName` and `rightClassName` and returns className for left and right props @acemac
-* fix functionality of `itemTitle` and `itemDivTitle` [issue](https://github.com/namespace-ee/react-calendar-timeline/issues/429#issuecomment-426456693) @acemac
+- Provided a new key `groupLabelKey` to allow splitting of the key used to render the Sidebar and the InfoLabel visible during drag operations. `groupTitleKey` continues to be used to render the Sidebar. #442 @thiagosatoshi
+- fix scroll left/right causes item move/edit to be at incorrect time #401 @acemac
+- now `getResizeProps` take `leftClassName` and `rightClassName` and returns className for left and right props @acemac
+- fix functionality of `itemTitle` and `itemDivTitle` [issue](https://github.com/namespace-ee/react-calendar-timeline/issues/429#issuecomment-426456693) @acemac
 
 ### 0.21.0
 
 #### fixes
 
-* fix item dimensions not being rendered on zoom in/out @ilaiwi + @acemac
-* correct `right_sidebar` to `rightTitle` in readme @maxlibin
+- fix item dimensions not being rendered on zoom in/out @ilaiwi + @acemac
+- correct `right_sidebar` to `rightTitle` in readme @maxlibin
 
 #### breaking changes
 
-* add `rct` to `.top-header` and `.bottom-header` to become `.rct-top-header` and `.rct-bottom-header` @Simek
-* upgrade dev dependance `react@16.3` @acemac
+- add `rct` to `.top-header` and `.bottom-header` to become `.rct-top-header` and `.rct-bottom-header` @Simek
+- upgrade dev dependance `react@16.3` @acemac
 
 ### 0.20.0
 
 ### improvements
 
-* eliminate extra renders on every scroll - #357 [acemac](https://github.com/acemac)
+- eliminate extra renders on every scroll - #357 [acemac](https://github.com/acemac)
 
 ### Fixed
 
-* When the `date` prop on a `CustomMarker` changes the marker will now move on the timeline - #421 [kevinmanncito](https://github.com/kevinmanncito) [ilaiwi](https://github.com/ilaiwi)
-* Header has a bounce effect - #311 [acemac](https://github.com/acemac)
+- When the `date` prop on a `CustomMarker` changes the marker will now move on the timeline - #421 [kevinmanncito](https://github.com/kevinmanncito) [ilaiwi](https://github.com/ilaiwi)
+- Header has a bounce effect - #311 [acemac](https://github.com/acemac)
 
 ####dev
 
-* update to `react-testing-library` version 5
-* remove deprecated `toBeInDom`
+- update to `react-testing-library` version 5
+- remove deprecated `toBeInDom`
 
 ### 0.19.0
 
 ### Added
 
-* ability to set classes for timeline columns depending on its time - #364
-* ability to add custom classes and custom heights to the timeline rows - #367
-* add `scrollRef` to allow for programmatically scrolling timeline - #372
+- ability to set classes for timeline columns depending on its time - #364
+- ability to add custom classes and custom heights to the timeline rows - #367
+- add `scrollRef` to allow for programmatically scrolling timeline - #372
 
 ### Breaking
 
-* rework item renderer to render the whole item using render prop and prop getters - #289
+- rework item renderer to render the whole item using render prop and prop getters - #289
 
 ### 0.18.2
 
 ### Fixed
 
-* `onCanvasClick` not fired - #383
-* cursor marker disappear while hovering over item - #378
+- `onCanvasClick` not fired - #383
+- cursor marker disappear while hovering over item - #378
 
 ### 0.18.1
 
 ### Fixed
 
-* Date passed to CursorMarker child is wrong - #379
-* groupRenderer doesnt work for right sidebar - #377
+- Date passed to CursorMarker child is wrong - #379
+- groupRenderer doesnt work for right sidebar - #377
 
 ### 0.18.0
 
 ### Fixed
 
-* Timeline now respects changes to `headerLabelFormats` and `subHeaderLabelFormats` - #362
+- Timeline now respects changes to `headerLabelFormats` and `subHeaderLabelFormats` - #362
 
 ### Added
 
-* timeline markers - user can have more control over markers that are rendered on the timeline. See `TimelineMarkers` section of README for documentation - #327
+- timeline markers - user can have more control over markers that are rendered on the timeline. See `TimelineMarkers` section of README for documentation - #327
 
 ### Breaking
 
-* Removed support for React 15 and lower. This is due to the fact that 16+ supports returning arrays from render, something that the TimelineMarker feature relies on.
-* removed `showCursorLine` prop in favor of using the `CursorMarker` component. See `TimelineMarkers` section of README for documentation.
+- Removed support for React 15 and lower. This is due to the fact that 16+ supports returning arrays from render, something that the TimelineMarker feature relies on.
+- removed `showCursorLine` prop in favor of using the `CursorMarker` component. See `TimelineMarkers` section of README for documentation.
 
 ```diff
 import Timeline,
@@ -336,96 +336,96 @@ from 'react-calendar-timeline'
 
 ### Added
 
-* fix issue with single row header - #359
+- fix issue with single row header - #359
 
 ### 0.17.2
 
 ### Added
 
-* support passing `style` prop from item - #347
-* `selected` is provided to `itemRenderer` - #348
-* simplify logic for calculate dimensions and prevent item width and left properties from being unbounded - (refactoring)
+- support passing `style` prop from item - #347
+- `selected` is provided to `itemRenderer` - #348
+- simplify logic for calculate dimensions and prevent item width and left properties from being unbounded - (refactoring)
 
 ### 0.17.1
 
 ### Added
 
-* pass canvasTimeStart/End via timelineContext to the itemRenderer prop
+- pass canvasTimeStart/End via timelineContext to the itemRenderer prop
 
 ### 0.17.0
 
 ### Breaking
 
-* throw more descriptive error if visibleTimeStart/End and defaultTimeStart/End are not passed as props. Timeline no longer calculates visibleTime start and end from items. Removed `onTimeInit` prop as it no longer serves a purpose. - #299
-* `interactjs` is a peerDependency (wasn't previously). Upped version to 1.3.4 to fix issue #297
+- throw more descriptive error if visibleTimeStart/End and defaultTimeStart/End are not passed as props. Timeline no longer calculates visibleTime start and end from items. Removed `onTimeInit` prop as it no longer serves a purpose. - #299
+- `interactjs` is a peerDependency (wasn't previously). Upped version to 1.3.4 to fix issue #297
 
 ### Fixed
 
-* fix for issue where NaN is returned in onItemMove if the startTime is not unix timestamp #300
+- fix for issue where NaN is returned in onItemMove if the startTime is not unix timestamp #300
 
 ### 0.16.3
 
 ### Fixed
 
-* tap on canvas now dispatches `onCanvasClicked` - #168
-* regression bug related to touch zoom
-* code cleanup and refactoring around group rows
+- tap on canvas now dispatches `onCanvasClicked` - #168
+- regression bug related to touch zoom
+- code cleanup and refactoring around group rows
 
 ### 0.16.2
 
 ### Fixed
 
-* clicking on canvas when item is selected now calls `onCanvasClicked` - #312
+- clicking on canvas when item is selected now calls `onCanvasClicked` - #312
 
 ### 0.16.1
 
 ### Added
 
-* added `stickyHeader` to disable/enable timeline header sticking on scroll.
-* removed `fullUpdate` prop and functionality. Labels rely on `position: sticky` to show for items that start before `visibleTimeStart`. This (should) greatly improve scroll performance.
-* removed extraneous css such as `text-align: center` on `.rct-item`, `.rct-item-overflow` to simplify the dom structure of `Item.js`
-* added `headerRef` callback to receive a reference to the header element. Due to the change in how the header positioning is implemented (i.e. using `position: sticky`), there is a need to use a polyfill in [certain browsers](https://caniuse.com/#feat=css-sticky) that don't support `position: sticky`. With a reference to the header dom element, you can use a polyfill to apply sticky behavior.
-* `minimumWidthForItemContentVisibility` prop to control at what width inner item content is rendered.
+- added `stickyHeader` to disable/enable timeline header sticking on scroll.
+- removed `fullUpdate` prop and functionality. Labels rely on `position: sticky` to show for items that start before `visibleTimeStart`. This (should) greatly improve scroll performance.
+- removed extraneous css such as `text-align: center` on `.rct-item`, `.rct-item-overflow` to simplify the dom structure of `Item.js`
+- added `headerRef` callback to receive a reference to the header element. Due to the change in how the header positioning is implemented (i.e. using `position: sticky`), there is a need to use a polyfill in [certain browsers](https://caniuse.com/#feat=css-sticky) that don't support `position: sticky`. With a reference to the header dom element, you can use a polyfill to apply sticky behavior.
+- `minimumWidthForItemContentVisibility` prop to control at what width inner item content is rendered.
 
 ### Breaking
 
-* removed `fixedHeader` prop in favor of using `position: sticky` by default
-* removed import of stylesheets in library code, put onus on user to handle this stylesheet
+- removed `fixedHeader` prop in favor of using `position: sticky` by default
+- removed import of stylesheets in library code, put onus on user to handle this stylesheet
 
 ## 0.15.12
 
 ### Fixed
 
-* Shift + Scroll via mouse wheel scrolls canvas horizontally - #281
+- Shift + Scroll via mouse wheel scrolls canvas horizontally - #281
 
 ## 0.15.11
 
 ### Fixed
 
-* removed `preventDefault` call in item double click handler - #277
+- removed `preventDefault` call in item double click handler - #277
 
 ## 0.15.10
 
 ### Fixed
 
-* fix issue with time report with onItem\* callbacks for browsers that don't support `x` property in rect object - #266
+- fix issue with time report with onItem\* callbacks for browsers that don't support `x` property in rect object - #266
 
 ## 0.15.9
 
 ### Fixed
 
-* header positioned incorrectly when not fixed/sticky - caused by #236
+- header positioned incorrectly when not fixed/sticky - caused by #236
 
 ## 0.15.8
 
 ### Fixed
 
-* propTypes error related to Item prop - #239
-* onCanvasClick and onCanvasDoubleClick were being called on header click - #236
+- propTypes error related to Item prop - #239
+- onCanvasClick and onCanvasDoubleClick were being called on header click - #236
 
 ### Added
 
-* on timeline zoom, onZoom prop is called with timelineContext - #248
+- on timeline zoom, onZoom prop is called with timelineContext - #248
 
 ## 0.15.7
 
@@ -433,31 +433,31 @@ This release contains a lot of code cleanup as well as an API change to the `ite
 
 ### Fixed
 
-* peerDependency warning if using React 16 #187
+- peerDependency warning if using React 16 #187
 
   ### Added
 
-* `timelineContext` is provided to `itemRenderer` #233
+- `timelineContext` is provided to `itemRenderer` #233
 
 ## 0.15.6
 
 ### Fixed
 
-* Fixed issue with state not properly updated when ending resize #173
-* Fixed issue with onItem\* events not reporting correct time when timeline has outer padding #227
+- Fixed issue with state not properly updated when ending resize #173
+- Fixed issue with onItem\* events not reporting correct time when timeline has outer padding #227
 
 ## 0.15.5
 
 ### Fixed
 
-* context click actually calls double click callback #225
-* Removed href attribute from header divs #222
+- context click actually calls double click callback #225
+- Removed href attribute from header divs #222
 
 ## 0.15.4
 
 ### Fixed
 
-* Clicking on Svg element throws error #216
+- Clicking on Svg element throws error #216
 
 ## 0.15.3
 
@@ -465,11 +465,11 @@ This version contains one crucial bug fix and a simple update to item clicks to 
 
 ### Added
 
-* Report time with all item clicks #210
+- Report time with all item clicks #210
 
 ### Fixed
 
-* Drag doesn't stop when you leave the timeline canvas #182
+- Drag doesn't stop when you leave the timeline canvas #182
 
 ## [0.15.0]
 
@@ -477,18 +477,18 @@ Plugin support and sticky header!
 
 ### Added
 
-* Plugins system (pass them as children) @mariusandra #122
-* Sticky header (`fixedHeader='sticky'`) @mariusandra #125
+- Plugins system (pass them as children) @mariusandra #122
+- Sticky header (`fixedHeader='sticky'`) @mariusandra #125
 
 ### Removed
 
-* [BREAKING] Removed deprecated option to pass sidebar header content as children. Use `sidebarContent` instead. @mariusandra
-* [BREAKING] Removed fixedHeader option `absolute`, which was broken and is now replaced with the option `sticky` @mariusandra
+- [BREAKING] Removed deprecated option to pass sidebar header content as children. Use `sidebarContent` instead. @mariusandra
+- [BREAKING] Removed fixedHeader option `absolute`, which was broken and is now replaced with the option `sticky` @mariusandra
 
 ### Demo & Docs
 
-* Notice for modern module bundlers @jlubben @mariusandra #128
-* Add [treeGroups](http://namespace.ee/react-calendar-timeline-docs/#/treeGroups) demo
+- Notice for modern module bundlers @jlubben @mariusandra #128
+- Add [treeGroups](http://namespace.ee/react-calendar-timeline-docs/#/treeGroups) demo
 
 ## [0.14.11]
 
@@ -496,106 +496,106 @@ Plenty of bugfixes, tests and new demos in these 0.14 patch releases.
 
 ### Fixed
 
-* Fixed bug with `resizeDetector` and with detecting changes in `sidebarWidth` @mariusandra
-* Fixed bug where order `0` was evaluated as a falsy @nicocrm #111
-* Fix overflow-x with header @signalwerk
+- Fixed bug with `resizeDetector` and with detecting changes in `sidebarWidth` @mariusandra
+- Fixed bug where order `0` was evaluated as a falsy @nicocrm #111
+- Fix overflow-x with header @signalwerk
 
 ### Added
 
-* Add meta+wheel modifier that zooms 3x the speed of the normal wheel events @mariusandra
+- Add meta+wheel modifier that zooms 3x the speed of the normal wheel events @mariusandra
 
 ### Changed
 
-* Refactor `calculateDimensions` to be pure @signalwerk
-* Convert `groupHeights` and `groupTops` to arrays (from objects) @mariusandra
+- Refactor `calculateDimensions` to be pure @signalwerk
+- Convert `groupHeights` and `groupTops` to arrays (from objects) @mariusandra
 
 ### Demo & docs
 
-* Add [linkedTimelines](http://namespace.ee/react-calendar-timeline-docs/#/linkedTimelines) demo
-* Add [elementResize](http://namespace.ee/react-calendar-timeline-docs/#/elementResize) demo
-* Add docs about modifier keys for zooming/scrolling @signalwerk
+- Add [linkedTimelines](http://namespace.ee/react-calendar-timeline-docs/#/linkedTimelines) demo
+- Add [elementResize](http://namespace.ee/react-calendar-timeline-docs/#/elementResize) demo
+- Add docs about modifier keys for zooming/scrolling @signalwerk
 
 ## [0.14.2]
 
 ### Changed
 
-* Use `prop-types` instead of `React.PropTypes` to support React 15.5+. @mariusandra #110
+- Use `prop-types` instead of `React.PropTypes` to support React 15.5+. @mariusandra #110
 
 ## [0.14.0]
 
 ### Added
 
-* Use `headerLabelFormats` and `subHeaderLabelFormats` to customise the header labels. @Slowyn #68
-* Optional pluggable `resizeDetector` to detect when the element's container is resized. @Ziller321 #94
+- Use `headerLabelFormats` and `subHeaderLabelFormats` to customise the header labels. @Slowyn #68
+- Optional pluggable `resizeDetector` to detect when the element's container is resized. @Ziller321 #94
 
 ### Fixed
 
-* Fix renders with empty `groups` array. @signalwerk #106
+- Fix renders with empty `groups` array. @signalwerk #106
 
 ## [0.13.0]
 
 ### Added
 
-* An option to add another sidebar to the right of the Timeline. @goooseman #80
-* `itemRenderer` prop to allow specifying a custom component to render the items @nicocrm #103
-* `groupRenderer` prop to allow specifying a custom component to render the groups @nicocrm #103
-* `showCursorLine` prop to show a vertical line at the snap position @meikoudras
-* You can now select multiple items if you take control of the `selected` prop and the `onItemSelect` handler. @meengit #71
-* Canvas context menu handler `onCanvasContextMenu` @meikoudras
+- An option to add another sidebar to the right of the Timeline. @goooseman #80
+- `itemRenderer` prop to allow specifying a custom component to render the items @nicocrm #103
+- `groupRenderer` prop to allow specifying a custom component to render the groups @nicocrm #103
+- `showCursorLine` prop to show a vertical line at the snap position @meikoudras
+- You can now select multiple items if you take control of the `selected` prop and the `onItemSelect` handler. @meengit #71
+- Canvas context menu handler `onCanvasContextMenu` @meikoudras
 
 ### Fixed
 
-* Calculate width when we receive sidebar width property @jmerriweather #75
-* Avoid updating updateDimensions right after updateScrollCanvas @nicocrm #87
-* Fix typo collision detection in stack() @nicocrm #96
-* Remove dead code @signalwerk #101
-* Disable cursor style by interactjs @bkniffler #89
-* Fixed header width and Header label weekday support @meikoudras #66
+- Calculate width when we receive sidebar width property @jmerriweather #75
+- Avoid updating updateDimensions right after updateScrollCanvas @nicocrm #87
+- Fix typo collision detection in stack() @nicocrm #96
+- Remove dead code @signalwerk #101
+- Disable cursor style by interactjs @bkniffler #89
+- Fixed header width and Header label weekday support @meikoudras #66
 
 ### Changed
 
-* [Deprecated] To have content above the left sidebar, pass it in a `sidebarContent={<div />}` prop, not as children to the component.
+- [Deprecated] To have content above the left sidebar, pass it in a `sidebarContent={<div />}` prop, not as children to the component.
 
 ## [0.11.1]
 
 ### Fixed
 
-* Without canResize prop in items it gave a Uncaught TypeError. @tgosp
+- Without canResize prop in items it gave a Uncaught TypeError. @tgosp
 
 ## [0.11.0]
 
 ### Added
 
-* An option to fully update the calendar at every scroll event. With this change, labels of items are always fully visible, even if looking at a multi day event with a zoom level set at 30min. @mariusandra
+- An option to fully update the calendar at every scroll event. With this change, labels of items are always fully visible, even if looking at a multi day event with a zoom level set at 30min. @mariusandra
 
 ## [0.10.1]
 
 ### Changed
 
-* The left resize edge mouse cursor is now a left arrow @mariusandra
+- The left resize edge mouse cursor is now a left arrow @mariusandra
 
 ## [0.10.0]
 
 ### Added
 
-* You can also resize items from the left now @mariusandra
+- You can also resize items from the left now @mariusandra
 
 ## [0.9.0]
 
 ### Added
 
-* Allow disabling selection clicks on items #58 by @sjchmiela
-* Allow passing additional props to `Item`'s `<div/>` #58 by @sjchmiela
-* Add `clickTolerance` so dragging more than 3 pixels is no longer a click @mariusandra
+- Allow disabling selection clicks on items #58 by @sjchmiela
+- Allow passing additional props to `Item`'s `<div/>` #58 by @sjchmiela
+- Add `clickTolerance` so dragging more than 3 pixels is no longer a click @mariusandra
 
 ### Changed
 
-* [BREAKING] Same arguments order (groupId, time, e) for onCanvasDoubleClick and onCanvasClick #52 by @signalwerk
-* [Deprecated] `onTimeChange` now gets `updateScrollCanvas` as the third argument. Doing `this.updateScrollCanvas` is no longer needed and will be removed soon.
-* Moved React & Moment from dependencies to peerDependencies #53 by @meikoudras
-* Fix resizing when inside DIV #47 by @semargal
-* Fix demo for IE11 #44 by @lucidlemon
-* Package a .css file, not a .scss file as previously done. @mariusandra
+- [BREAKING] Same arguments order (groupId, time, e) for onCanvasDoubleClick and onCanvasClick #52 by @signalwerk
+- [Deprecated] `onTimeChange` now gets `updateScrollCanvas` as the third argument. Doing `this.updateScrollCanvas` is no longer needed and will be removed soon.
+- Moved React & Moment from dependencies to peerDependencies #53 by @meikoudras
+- Fix resizing when inside DIV #47 by @semargal
+- Fix demo for IE11 #44 by @lucidlemon
+- Package a .css file, not a .scss file as previously done. @mariusandra
 
 [0.9.0]: https://github.com/namespace-ee/react-calendar-timeline/compare/v0.8.6...v0.9.0
 [0.10.0]: https://github.com/namespace-ee/react-calendar-timeline/compare/v0.9.0...v0.10.0

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -4,13 +4,9 @@ import moment from 'moment'
 
 import Timeline, {
   TimelineMarkers,
-  TimelineHeaders,
   TodayMarker,
   CustomMarker,
-  CursorMarker,
-  CustomHeader,
-  SidebarHeader,
-  DateHeader
+  CursorMarker
 } from 'react-calendar-timeline'
 
 import generateFakeData from '../generate-fake-data'
@@ -89,15 +85,14 @@ export default class App extends Component {
     const group = groups[newGroupOrder]
 
     this.setState({
-      items: items.map(
-        item =>
-          item.id === itemId
-            ? Object.assign({}, item, {
-                start: dragTime,
-                end: dragTime + (item.end - item.start),
-                group: group.id
-              })
-            : item
+      items: items.map(item =>
+        item.id === itemId
+          ? Object.assign({}, item, {
+              start: dragTime,
+              end: dragTime + (item.end - item.start),
+              group: group.id
+            })
+          : item
       )
     })
 
@@ -108,14 +103,13 @@ export default class App extends Component {
     const { items } = this.state
 
     this.setState({
-      items: items.map(
-        item =>
-          item.id === itemId
-            ? Object.assign({}, item, {
-                start: edge === 'left' ? time : item.start,
-                end: edge === 'left' ? item.end : time
-              })
-            : item
+      items: items.map(item =>
+        item.id === itemId
+          ? Object.assign({}, item, {
+              start: edge === 'left' ? time : item.start,
+              end: edge === 'left' ? item.end : time
+            })
+          : item
       )
     })
 

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -16,7 +16,8 @@ const demos = {
   customItems: require('./demo-custom-items').default,
   customHeaders: require('./demo-headers').default,
   customInfoLabel: require('./demo-custom-info-label').default,
-  controledSelect: require('./demo-controlled-select').default
+  controledSelect: require('./demo-controlled-select').default,
+  tempControlled: require('./demo-temp-controlled').default
 }
 
 // A simple component that shows the pathname of the current location

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import moment from 'moment'
 
 import Items from './items/Items'
 import Sidebar from './layout/Sidebar'
@@ -12,7 +11,6 @@ import windowResizeDetector from '../resize-detector/window'
 
 import {
   getMinUnit,
-  getNextUnit,
   calculateTimeForXPosition,
   calculateScrollCanvas,
   getCanvasBoundariesFromVisibleTime,
@@ -31,7 +29,6 @@ import { TimelineMarkersProvider } from './markers/TimelineMarkersContext'
 import { TimelineHeadersProvider } from './headers/HeadersContext'
 import TimelineHeaders from './headers/TimelineHeaders'
 import DateHeader from './headers/DateHeader'
-import SidebarHeader from './headers/SidebarHeader'
 
 export default class ReactCalendarTimeline extends Component {
   static propTypes = {
@@ -271,10 +268,11 @@ export default class ReactCalendarTimeline extends Component {
 
     this.getSelected = this.getSelected.bind(this)
     this.hasSelectedItem = this.hasSelectedItem.bind(this)
-    this.isItemSelected= this.isItemSelected.bind(this)
+    this.isItemSelected = this.isItemSelected.bind(this)
 
     let visibleTimeStart = null
     let visibleTimeEnd = null
+    let isControlled = false
 
     if (this.props.defaultTimeStart && this.props.defaultTimeEnd) {
       visibleTimeStart = this.props.defaultTimeStart.valueOf()
@@ -282,6 +280,7 @@ export default class ReactCalendarTimeline extends Component {
     } else if (this.props.visibleTimeStart && this.props.visibleTimeEnd) {
       visibleTimeStart = this.props.visibleTimeStart
       visibleTimeEnd = this.props.visibleTimeEnd
+      isControlled = true
     } else {
       //throwing an error because neither default or visible time props provided
       throw new Error(
@@ -305,7 +304,8 @@ export default class ReactCalendarTimeline extends Component {
       dragGroupTitle: null,
       resizeTime: null,
       resizingItem: null,
-      resizingEdge: null
+      resizingEdge: null,
+      isControlled
     }
 
     const canvasWidth = getCanvasWidth(this.state.width)
@@ -411,7 +411,7 @@ export default class ReactCalendarTimeline extends Component {
         )
       )
     }
-    
+
     return derivedState
   }
 
@@ -437,13 +437,13 @@ export default class ReactCalendarTimeline extends Component {
 
     // Check the scroll is correct
     const scrollLeft = Math.round(
-      this.state.width *
-        (this.state.visibleTimeStart - this.state.canvasTimeStart) /
+      (this.state.width *
+        (this.state.visibleTimeStart - this.state.canvasTimeStart)) /
         newZoom
     )
     const componentScrollLeft = Math.round(
-      prevState.width *
-        (prevState.visibleTimeStart - prevState.canvasTimeStart) /
+      (prevState.width *
+        (prevState.visibleTimeStart - prevState.canvasTimeStart)) /
         oldZoom
     )
     if (componentScrollLeft !== scrollLeft) {
@@ -502,7 +502,7 @@ export default class ReactCalendarTimeline extends Component {
 
     const zoom = this.state.visibleTimeEnd - this.state.visibleTimeStart
 
-    const visibleTimeStart = canvasTimeStart + zoom * scrollX / width
+    const visibleTimeStart = canvasTimeStart + (zoom * scrollX) / width
 
     if (
       this.state.visibleTimeStart !== visibleTimeStart ||
@@ -538,7 +538,7 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   handleWheelZoom = (speed, xPosition, deltaY) => {
-    this.changeZoom(1.0 + speed * deltaY / 500, xPosition / this.state.width)
+    this.changeZoom(1.0 + (speed * deltaY) / 500, xPosition / this.state.width)
   }
 
   changeZoom = (scale, offset = 0.5) => {
@@ -871,13 +871,13 @@ export default class ReactCalendarTimeline extends Component {
 
   /**
    * check if child of type TimelineHeader
-   * refer to for explanation https://github.com/gaearon/react-hot-loader#checking-element-types 
+   * refer to for explanation https://github.com/gaearon/react-hot-loader#checking-element-types
    */
-  isTimelineHeader = (child) => {
-    if(child.type === undefined) return false
-    return child.type.secretKey ===TimelineHeaders.secretKey
+  isTimelineHeader = child => {
+    if (child.type === undefined) return false
+    return child.type.secretKey === TimelineHeaders.secretKey
   }
-  
+
   childrenWithProps(
     canvasTimeStart,
     canvasTimeEnd,
@@ -950,15 +950,15 @@ export default class ReactCalendarTimeline extends Component {
   getSelected() {
     return this.state.selectedItem && !this.props.selected
       ? [this.state.selectedItem]
-      : this.props.selected || [];
+      : this.props.selected || []
   }
 
-  hasSelectedItem(){
-    if(!Array.isArray(this.props.selected)) return !!this.state.selectedItem
+  hasSelectedItem() {
+    if (!Array.isArray(this.props.selected)) return !!this.state.selectedItem
     return this.props.selected.length > 0
   }
 
-  isItemSelected(itemId){
+  isItemSelected(itemId) {
     const selectedItems = this.getSelected()
     return selectedItems.some(i => i === itemId)
   }
@@ -983,7 +983,8 @@ export default class ReactCalendarTimeline extends Component {
       visibleTimeStart,
       visibleTimeEnd,
       canvasTimeStart,
-      canvasTimeEnd
+      canvasTimeEnd,
+      isControlled
     } = this.state
     let { dimensionItems, height, groupHeights, groupTops } = this.state
 
@@ -1048,6 +1049,7 @@ export default class ReactCalendarTimeline extends Component {
               <div style={outerComponentStyle} className="rct-outer">
                 {sidebarWidth > 0 ? this.sidebar(height, groupHeights) : null}
                 <ScrollElement
+                  isControlled={isControlled}
                   scrollRef={this.getScrollElementRef}
                   width={width}
                   height={height}

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -12,7 +12,8 @@ class ScrollElement extends Component {
     isInteractingWithItem: PropTypes.bool.isRequired,
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
-    onScroll: PropTypes.func.isRequired
+    onScroll: PropTypes.func.isRequired,
+    isControlled: PropTypes.bool.isRequired
   }
 
   constructor() {
@@ -33,16 +34,13 @@ class ScrollElement extends Component {
   refHandler = el => {
     this.scrollComponent = el
     this.props.scrollRef(el)
-    if(el){
-      el.addEventListener('wheel', this.handleWheel, {passive: false});
+    if (el) {
+      el.addEventListener('wheel', this.handleWheel, { passive: false })
     }
   }
-  
 
   handleWheel = e => {
     const { traditionalZoom } = this.props
-
-    
 
     // zoom in the time dimension
     if (e.ctrlKey || e.metaKey || e.altKey) {
@@ -57,7 +55,9 @@ class ScrollElement extends Component {
     } else if (e.shiftKey) {
       e.preventDefault()
       // shift+scroll event from a touchpad has deltaY property populated; shift+scroll event from a mouse has deltaX
-      this.props.onScroll(this.scrollComponent.scrollLeft + (e.deltaY || e.deltaX))
+      this.props.onScroll(
+        this.scrollComponent.scrollLeft + (e.deltaY || e.deltaX)
+      )
       // no modifier pressed? we prevented the default event, so scroll or zoom as needed
     }
   }
@@ -76,7 +76,9 @@ class ScrollElement extends Component {
     // this.props.onMouseMove(e)
     //why is interacting with item important?
     if (this.state.isDragging && !this.props.isInteractingWithItem) {
-      this.props.onScroll(this.scrollComponent.scrollLeft + this.dragLastPosition - e.pageX)
+      this.props.onScroll(
+        this.scrollComponent.scrollLeft + this.dragLastPosition - e.pageX
+      )
       this.dragLastPosition = e.pageX
     }
   }
@@ -168,21 +170,22 @@ class ScrollElement extends Component {
     }
   }
 
-  componentWillUnmount(){
-    if(this.scrollComponent){
-      this.scrollComponent.removeEventListener('wheel', this.handleWheel);
+  componentWillUnmount() {
+    if (this.scrollComponent) {
+      this.scrollComponent.removeEventListener('wheel', this.handleWheel)
     }
   }
 
   render() {
-    const { width, height, children } = this.props
+    const { width, height, children, isControlled } = this.props
     const { isDragging } = this.state
 
     const scrollComponentStyle = {
       width: `${width}px`,
       height: `${height + 20}px`, //20px to push the scroll element down off screen...?
       cursor: isDragging ? 'move' : 'default',
-      position: 'relative'
+      position: 'relative',
+      overflowX: isControlled ? 'hidden' : 'initial'
     }
 
     return (
@@ -202,7 +205,6 @@ class ScrollElement extends Component {
       >
         {children}
       </div>
-
     )
   }
 }


### PR DESCRIPTION
**Issue Number**
- #713 and #537 

**Overview of PR**
- Prevent side scrolling via trackpad and mouse by setting ```overflowX: 'hidden'``` when ```visibleTimeStart``` or ```visibleTimeEnd``` are passed to ```Timeline```
