### PR TITLE
fix controlled mode side scrolling via CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 ## Unreleased
 
 * Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
+* Fix `visibleTimeStart`, `visibleTimeEnd` and `onTimeChange` scrolling behavior with trackpad and mouse side scrolling
 
 ## 0.26.7
 

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -271,10 +271,11 @@ export default class ReactCalendarTimeline extends Component {
 
     this.getSelected = this.getSelected.bind(this)
     this.hasSelectedItem = this.hasSelectedItem.bind(this)
-    this.isItemSelected= this.isItemSelected.bind(this)
+    this.isItemSelected = this.isItemSelected.bind(this)
 
     let visibleTimeStart = null
     let visibleTimeEnd = null
+    let isControlled = false
 
     if (this.props.defaultTimeStart && this.props.defaultTimeEnd) {
       visibleTimeStart = this.props.defaultTimeStart.valueOf()
@@ -282,6 +283,7 @@ export default class ReactCalendarTimeline extends Component {
     } else if (this.props.visibleTimeStart && this.props.visibleTimeEnd) {
       visibleTimeStart = this.props.visibleTimeStart
       visibleTimeEnd = this.props.visibleTimeEnd
+      isControlled = true
     } else {
       //throwing an error because neither default or visible time props provided
       throw new Error(
@@ -305,7 +307,8 @@ export default class ReactCalendarTimeline extends Component {
       dragGroupTitle: null,
       resizeTime: null,
       resizingItem: null,
-      resizingEdge: null
+      resizingEdge: null,
+      isControlled
     }
 
     const canvasWidth = getCanvasWidth(this.state.width)
@@ -983,7 +986,8 @@ export default class ReactCalendarTimeline extends Component {
       visibleTimeStart,
       visibleTimeEnd,
       canvasTimeStart,
-      canvasTimeEnd
+      canvasTimeEnd,
+      isControlled
     } = this.state
     let { dimensionItems, height, groupHeights, groupTops } = this.state
 
@@ -1056,6 +1060,7 @@ export default class ReactCalendarTimeline extends Component {
                   traditionalZoom={traditionalZoom}
                   onScroll={this.onScroll}
                   isInteractingWithItem={isInteractingWithItem}
+                  isControlled={isControlled}
                 >
                   <MarkerCanvas>
                     {this.columns(

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -12,7 +12,8 @@ class ScrollElement extends Component {
     isInteractingWithItem: PropTypes.bool.isRequired,
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
-    onScroll: PropTypes.func.isRequired
+    onScroll: PropTypes.func.isRequired,
+    isControlled: PropTypes.bool.isRequired
   }
 
   constructor() {
@@ -175,14 +176,15 @@ class ScrollElement extends Component {
   }
 
   render() {
-    const { width, height, children } = this.props
+    const { width, height, children, isControlled } = this.props
     const { isDragging } = this.state
 
     const scrollComponentStyle = {
       width: `${width}px`,
       height: `${height + 20}px`, //20px to push the scroll element down off screen...?
       cursor: isDragging ? 'move' : 'default',
-      position: 'relative'
+      position: 'relative',
+      overflowX: isControlled ? 'hidden' : 'initial'
     }
 
     return (


### PR DESCRIPTION
**Issue Number**
- #713 and #537 

**Overview of PR**
- Prevent side scrolling via trackpad and mouse by setting ```overflowX: 'hidden'``` when ```visibleTimeStart``` or ```visibleTimeEnd``` are passed to ```Timeline```
