### PR TITLE
fix drag events to use current groupId if canChangeGroup is falsey

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Data to be passed to `rowRenderer`'s  `rowData` param. Changing this prop will c
 
 # Helpers
 
-Helpers are methods provided by `HelperContext`. These helpers power most of the rendered UI in the timeline like: Headers, Markers, Items and row renderers. 
+Helpers are methods provided by `HelperContext`. These helpers power most of the rendered UI in the timeline like: Headers, Markers, Items and row renderers.
 
 ## Methods
 
@@ -598,7 +598,7 @@ Given `left` position in `px`, the method will return the corresponding date in 
 
 Given a item id, It will return back the left and top of the item relative to row it is in. This is useful to know the where an item is relative to other items in the same row.
 
-### `getItemAbsoluteDimensions(itemId: string|number): dimensions`. 
+### `getItemAbsoluteDimensions(itemId: string|number): dimensions`.
 
 Given a item id, It will return back the left and top of the item relative to the calendar container. This is useful to know the position of items in different rows relative to each other.
 
@@ -858,7 +858,7 @@ Custom renderer for this marker. Ensure that you always pass `styles` to the roo
 ```
 
 
-Helpers are a group of 
+Helpers are a group of
 
 # Timeline Headers
 
@@ -1448,7 +1448,7 @@ type rowRenderer = (args: Params) => React.Node
 
 ### getLayerRootProps
 
-These functions are used to apply props to the layer that you want to render. This gives you maximum flexibility to render what, when, and wherever you like. 
+These functions are used to apply props to the layer that you want to render. This gives you maximum flexibility to render what, when, and wherever you like.
 
 ### rowData
 
@@ -1460,7 +1460,7 @@ current group being rendered in the row.
 
 ### itemsWithInteractions
 
-items to be rendered in the row. These items respect visibility and interaction. This means that the items you will get back are only the items in the visible + buffer zone and if dragging/resizing is happening you will get the items the start/end time with the interaction.  
+items to be rendered in the row. These items respect visibility and interaction. This means that the items you will get back are only the items in the visible + buffer zone and if dragging/resizing is happening you will get the items the start/end time with the interaction.
 
 ## Components
 
@@ -1640,7 +1640,7 @@ $ yarn start
 
 Check http://0.0.0.0:8888/ in your browser and have fun!
 
-Please run `npm run lint` before you send a pull request. `npm run jest` runs the tests.
+Please run `npm run lint` before you send a pull request. `npm run test` runs the tests.
 
 <!--
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublish": "npm run build:lib",
     "start": "webpack-dev-server --hot --host 0.0.0.0 --display-modules",
     "test": "jest",
-    "test:watch": "jest --watch"  
+    "test:watch": "jest --watch"
   },
   "files": [
     "lib",

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -67,7 +67,7 @@ export default class Item extends Component {
     dragOffset: PropTypes.number.isRequired,
     resizeEdge: PropTypes.oneOf(['left', 'right']),
     resizeStart: PropTypes.number,
-  
+
     onDragStart: PropTypes.func.isRequired,
     onDragEnd : PropTypes.func.isRequired,
     onResizeStart: PropTypes.func.isRequired,
@@ -97,7 +97,7 @@ export default class Item extends Component {
       nextProps.canvasTimeStart !== this.props.canvasTimeStart ||
       nextProps.canvasTimeEnd !== this.props.canvasTimeEnd ||
       nextProps.canvasWidth !== this.props.canvasWidth ||
-      (nextProps.order ? nextProps.order.index : undefined) !== 
+      (nextProps.order ? nextProps.order.index : undefined) !==
         (this.props.order ? this.props.order.index : undefined) ||
       nextProps.dragSnap !== this.props.dragSnap ||
       nextProps.minResizeWidth !== this.props.minResizeWidth ||
@@ -161,7 +161,7 @@ export default class Item extends Component {
 
     const offset = getSumOffset(this.props.scrollRef).offsetLeft
     const scrolls = getSumScroll(this.props.scrollRef)
-      
+
     return (e.pageX - offset + scrolls.scrollLeft) * ratio + this.props.canvasTimeStart;
   }
 
@@ -216,13 +216,13 @@ export default class Item extends Component {
         e.stopPropagation()
         if (this.props.dragging) {
           if (e.dropzone) {
-            const newGroupId = e.dropzone.target.dataset.groupid
+            const newGroupId = this.props.canChangeGroup ? e.dropzone.target.dataset.groupid : this.itemGroupId
             let dragTime = this.dragTime(e)
             if(dragTime !== _get(this.props.item, this.props.keys.itemTimeStartKey)){
               if (this.props.moveResizeValidator) {
                 dragTime = this.props.moveResizeValidator('move', this.props.item, dragTime)
               }
-  
+
               if (this.props.onDrag) {
                 this.props.onDrag(this.itemId, dragTime, newGroupId)
               }
@@ -235,17 +235,17 @@ export default class Item extends Component {
         if (this.props.dragging) {
           if(e.dropzone){
 
-            const newGroupId = e.dropzone.target.dataset.groupid
+            const newGroupId = this.props.canChangeGroup ? e.dropzone.target.dataset.groupid : this.itemGroupId
             if (this.props.onDrop) {
               let dragTime = this.dragTime(e)
-              
+
               if (this.props.moveResizeValidator) {
                 dragTime = this.props.moveResizeValidator('move', this.props.item, dragTime)
               }
-              
+
               this.props.onDrop(this.itemId, dragTime, newGroupId)
             }
-            
+
           }
           this.props.onDragEnd()
         }
@@ -347,7 +347,7 @@ export default class Item extends Component {
       ) {
         const leftResize = this.props.useResizeHandle ? this.dragLeft : true
         const rightResize = this.props.useResizeHandle ? this.dragRight : true
-  
+
         interact(this.item).resizable({
           enabled: willBeAbleToResizeLeft || willBeAbleToResizeRight,
           edges: {
@@ -537,7 +537,7 @@ export default class Item extends Component {
       visibleTimeEnd: this.props.visibleTimeEnd,
       visibleTimeStart: this.props.visibleTimeStart,
       timelineWidth: this.props.timelineWidth,
-  
+
     }
 
     const itemContext = {
@@ -556,7 +556,7 @@ export default class Item extends Component {
       resizeEdge: this.props.resizeEdge,
       resizeStart: this.props.resizeStart,
       resizeTime: this.props.resizeEdge !== undefined ?
-        this.props.resizeEdge === 'right'? 
+        this.props.resizeEdge === 'right'?
           this.itemTimeEnd
           : this.itemTimeStart
         : null ,


### PR DESCRIPTION
**Issue Number**

[Bug Report in Row Renderer RFC Comments Section](https://github.com/namespace-ee/react-calendar-timeline/issues/656#issuecomment-554428829)

**Overview of PR**

- Update `"dragmove"` and `"dragend"` to use current group id if `canChangeGroup` is falsey.
- Update readme to show `npm run test` instead of `npm run jest` due to `package.json` having a `"test"` command. 
- minor automatic white space fixes in the touched files. 
