### PR TITLE
update create-react-context version to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "create-react-context": "^0.2.2",
+    "create-react-context": "^0.3.0",
     "element-resize-detector": "^1.1.12",
     "lodash.isequal": "^4.5.0",
     "memoize-one": "^5.1.1"


### PR DESCRIPTION
**Issue Number**
#748 

**Overview of PR**

Update create-react-context v0.3.0 because the previous v.2.3 include text in the license file which could block its usage as an open-source lib. Those text are removed from create-react-context v0.3.0.

