### PR TITLE
Fix disable scroll on controlled visible time 713

### DIFF
--- a/demo/app/demo-controlled-visible-time/index.js
+++ b/demo/app/demo-controlled-visible-time/index.js
@@ -1,0 +1,82 @@
+import React, { Component } from "react";
+import moment from "moment";
+
+import Timeline from "react-calendar-timeline";
+
+import generateFakeData from "../generate-fake-data";
+
+var keys = {
+  groupIdKey: "id",
+  groupTitleKey: "title",
+  groupRightTitleKey: "rightTitle",
+  itemIdKey: "id",
+  itemTitleKey: "title",
+  itemDivTitleKey: "title",
+  itemGroupKey: "group",
+  itemTimeStartKey: "start",
+  itemTimeEndKey: "end",
+  groupLabelKey: "title"
+};
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+
+    const { groups, items } = generateFakeData();
+    const visibleTimeStart = moment()
+      .startOf("day")
+      .valueOf();
+    const visibleTimeEnd = moment()
+      .startOf("day")
+      .add(1, "day")
+      .valueOf();
+
+    this.state = {
+      groups,
+      items,
+      visibleTimeStart,
+      visibleTimeEnd
+    };
+  }
+
+  onPrevClick = () => {
+    const zoom = this.state.visibleTimeEnd - this.state.visibleTimeStart;
+    this.setState(state => ({
+      visibleTimeStart: state.visibleTimeStart - zoom,
+      visibleTimeEnd: state.visibleTimeEnd - zoom
+    }));
+  };
+
+  onNextClick = () => {
+    const zoom = this.state.visibleTimeEnd - this.state.visibleTimeStart;
+    this.setState(state => ({
+      visibleTimeStart: state.visibleTimeStart + zoom,
+      visibleTimeEnd: state.visibleTimeEnd + zoom
+    }));
+  };
+
+  render() {
+    const { groups, items, visibleTimeStart, visibleTimeEnd } = this.state;
+
+    return (
+      <div>
+        <button onClick={this.onPrevClick}>{"< Prev"}</button>
+        <button onClick={this.onNextClick}>{"Next >"}</button>
+        <Timeline
+          scrollRef={el => (this.scrollRef = el)}
+          groups={groups}
+          items={items}
+          keys={keys}
+          itemTouchSendsClick={false}
+          stackItems
+          itemHeightRatio={0.75}
+          showCursorLine
+          canMove={false}
+          canResize={false}
+          visibleTimeStart={visibleTimeStart}
+          visibleTimeEnd={visibleTimeEnd}
+        />
+      </div>
+    );
+  }
+}

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -16,7 +16,8 @@ const demos = {
   customItems: require('./demo-custom-items').default,
   customHeaders: require('./demo-headers').default,
   customInfoLabel: require('./demo-custom-info-label').default,
-  controledSelect: require('./demo-controlled-select').default
+  controledSelect: require('./demo-controlled-select').default,
+  controlledVisibleTime: require('./demo-controlled-visible-time').default
 }
 
 // A simple component that shows the pathname of the current location

--- a/src/lib/utility/generic.js
+++ b/src/lib/utility/generic.js
@@ -34,3 +34,5 @@ export function keyBy(value, key) {
 }
 
 export function noop() {}
+
+export const isNumber = n => !isNaN(n);


### PR DESCRIPTION
**Issue Number**

[Addressed issue](https://github.com/namespace-ee/react-calendar-timeline/issues/713)

**Overview of PR**

Work done:
1. subscribed to `touchmove`, `wheel` and `keydown` events to prevent scroll when visibleTimeStart and visibleTimeEnd are present (there existence as props will denote that the Timeline component is controlled).
2. Added a demo that already exists [here](https://codesandbox.io/s/timeline-demo-controlled-visible-time-no-scroll-659jb) to demo results

Notes: 
1. I ran `npm run lint` but there are already lint errors
2. I ran `npm run test` but the failing tests on master are the same that are failing on my branch