### PR TITLE
limit item dragging between groups (improve moveResizeValidator via dragGroupDelta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Called when the canvas is clicked by the right button of the mouse. Note: If thi
 
 Called when the timeline is zoomed, either via mouse/pinch zoom or clicking header to change timeline units
 
-## moveResizeValidator(action, itemId, time, resizeEdge)
+## moveResizeValidator(action, itemId, time, resizeEdge, dragOrderIndex?, dragGroupDelta?)
 
 This function is called when an item is being moved or resized. It's up to this function to return a new version of `change`, when the proposed move would violate business logic.
 
@@ -326,7 +326,13 @@ The argument `resizeEdge` is when resizing one of `left` or `right`.
 
 The argument `time` describes the proposed new time for either the start time of the item (for move) or the start or end time (for resize).
 
+The argument `dragOrderIndex` is  group index item belonged to before dragging. [optional, exists only in dragging/move]
+
+The argument `dragGroupDelta` is  group index difference we should move item to on/after dragging. [optional, exists only in dragging/move]
+
 The function must return a new unix timestamp in milliseconds... or just `time` if the proposed new time doesn't interfere with business logic.
+
+Optionally in 'move' action you can return an object with `dragTime` timestamp in ms and `dragGroupDelta` final group index shift (integer number)
 
 For example, to prevent moving of items into the past, but to keep them at 15min intervals, use this code:
 
@@ -435,8 +441,8 @@ Rather than applying props on the element yourself and to avoid your props being
   * onTouchEnd: event handler
   * onDoubleClick: event handler
   * onContextMenu: event handler
-  * style: inline object 
-  
+  * style: inline object
+
 
   \*\* _the given styles will only override the styles that are not a requirement for positioning the item. Other styles like `color`, `radius` and others_
 

--- a/demo/app/demo-limit-group-movement/index.js
+++ b/demo/app/demo-limit-group-movement/index.js
@@ -1,0 +1,212 @@
+/* eslint-disable no-console */
+import React, { Component } from 'react'
+import moment from 'moment'
+
+import Timeline, {
+  TimelineMarkers,
+  TimelineHeaders,
+  TodayMarker,
+  CustomMarker,
+  CursorMarker,
+  CustomHeader,
+  SidebarHeader,
+  DateHeader
+} from 'react-calendar-timeline'
+
+import generateFakeData from '../generate-fake-data'
+
+var minTime = moment()
+  .add(-6, 'months')
+  .valueOf()
+var maxTime = moment()
+  .add(6, 'months')
+  .valueOf()
+
+var keys = {
+  groupIdKey: 'id',
+  groupTitleKey: 'title',
+  groupRightTitleKey: 'rightTitle',
+  itemIdKey: 'id',
+  itemTitleKey: 'title',
+  itemDivTitleKey: 'title',
+  itemGroupKey: 'group',
+  itemTimeStartKey: 'start',
+  itemTimeEndKey: 'end'
+}
+
+export default class App extends Component {
+  constructor(props) {
+    super(props)
+
+    const { groups, items } = generateFakeData()
+    const defaultTimeStart = moment()
+      .startOf('day')
+      .toDate()
+    const defaultTimeEnd = moment()
+      .startOf('day')
+      .add(1, 'day')
+      .toDate()
+
+    this.state = {
+      groups,
+      items,
+      defaultTimeStart,
+      defaultTimeEnd
+    }
+  }
+
+  handleCanvasClick = (groupId, time) => {
+    console.log('Canvas clicked', groupId, moment(time).format())
+  }
+
+  handleCanvasDoubleClick = (groupId, time) => {
+    console.log('Canvas double clicked', groupId, moment(time).format())
+  }
+
+  handleCanvasContextMenu = (group, time) => {
+    console.log('Canvas context menu', group, moment(time).format())
+  }
+
+  handleItemClick = (itemId, _, time) => {
+    console.log('Clicked: ' + itemId, moment(time).format())
+  }
+
+  handleItemSelect = (itemId, _, time) => {
+    console.log('Selected: ' + itemId, moment(time).format())
+  }
+
+  handleItemDoubleClick = (itemId, _, time) => {
+    console.log('Double Click: ' + itemId, moment(time).format())
+  }
+
+  handleItemContextMenu = (itemId, _, time) => {
+    console.log('Context Menu: ' + itemId, moment(time).format())
+  }
+
+  handleItemMove = (itemId, dragTime, newGroupOrder) => {
+    const { items, groups } = this.state
+
+    const group = groups[newGroupOrder]
+
+    this.setState({
+      items: items.map(
+        item =>
+          item.id === itemId
+            ? Object.assign({}, item, {
+                start: dragTime,
+                end: dragTime + (item.end - item.start),
+                group: group.id
+              })
+            : item
+      )
+    })
+
+    console.log('Moved', itemId, dragTime, newGroupOrder)
+  }
+
+  handleItemResize = (itemId, time, edge) => {
+    const { items } = this.state
+
+    this.setState({
+      items: items.map(
+        item =>
+          item.id === itemId
+            ? Object.assign({}, item, {
+                start: edge === 'left' ? time : item.start,
+                end: edge === 'left' ? item.end : time
+              })
+            : item
+      )
+    })
+
+    console.log('Resized', itemId, time, edge)
+  }
+
+  // this limits the timeline to -6 months ... +6 months
+  handleTimeChange = (visibleTimeStart, visibleTimeEnd, updateScrollCanvas) => {
+    if (visibleTimeStart < minTime && visibleTimeEnd > maxTime) {
+      updateScrollCanvas(minTime, maxTime)
+    } else if (visibleTimeStart < minTime) {
+      updateScrollCanvas(minTime, minTime + (visibleTimeEnd - visibleTimeStart))
+    } else if (visibleTimeEnd > maxTime) {
+      updateScrollCanvas(maxTime - (visibleTimeEnd - visibleTimeStart), maxTime)
+    } else {
+      updateScrollCanvas(visibleTimeStart, visibleTimeEnd)
+    }
+  }
+
+  moveResizeValidator = (action, item, time, resizeEdge, index, delta) => {
+    let newTime = time;
+    if (time < new Date().getTime()) {
+      newTime =
+        Math.ceil(new Date().getTime() / (15 * 60 * 1000)) * (15 * 60 * 1000)
+    }
+
+    // move items only in checker style
+    // (odd rows to odd rows only and even rows to even rows)
+
+    if ((index + delta) % 2 !== index % 2) {
+      const moveDelta = (index + delta >= this.state.groups.length - 1) ? -1 : 1
+      return {dragTime: newTime, dragGroupDelta: delta + moveDelta};
+    }
+
+    return newTime
+  }
+
+  render() {
+    const { groups, items, defaultTimeStart, defaultTimeEnd } = this.state
+
+    return (
+      <Timeline
+        groups={groups}
+        items={items}
+        keys={keys}
+        sidebarWidth={150}
+        sidebarContent={<div>Above The Left</div>}
+        canMove
+        canResize="right"
+        canSelect
+        itemsSorted
+        itemTouchSendsClick={false}
+        stackItems
+        itemHeightRatio={0.75}
+        defaultTimeStart={defaultTimeStart}
+        defaultTimeEnd={defaultTimeEnd}
+        onCanvasClick={this.handleCanvasClick}
+        onCanvasDoubleClick={this.handleCanvasDoubleClick}
+        onCanvasContextMenu={this.handleCanvasContextMenu}
+        onItemClick={this.handleItemClick}
+        onItemSelect={this.handleItemSelect}
+        onItemContextMenu={this.handleItemContextMenu}
+        onItemMove={this.handleItemMove}
+        onItemResize={this.handleItemResize}
+        onItemDoubleClick={this.handleItemDoubleClick}
+        onTimeChange={this.handleTimeChange}
+        moveResizeValidator={this.moveResizeValidator}
+      >
+        <TimelineMarkers>
+          <TodayMarker />
+          <CustomMarker
+            date={
+              moment()
+                .startOf('day')
+                .valueOf() +
+              1000 * 60 * 60 * 2
+            }
+          />
+          <CustomMarker
+            date={moment()
+              .add(3, 'day')
+              .valueOf()}
+          >
+            {({ styles }) => {
+              const newStyles = { ...styles, backgroundColor: 'blue' }
+              return <div style={newStyles} />
+            }}
+          </CustomMarker>
+          <CursorMarker />
+        </TimelineMarkers>
+      </Timeline>
+    )
+  }
+}

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -16,7 +16,8 @@ const demos = {
   customItems: require('./demo-custom-items').default,
   customHeaders: require('./demo-headers').default,
   customInfoLabel: require('./demo-custom-info-label').default,
-  controledSelect: require('./demo-controlled-select').default
+  controledSelect: require('./demo-controlled-select').default,
+  limitGroupMovement: require('./demo-limit-group-movement').default
 }
 
 // A simple component that shows the pathname of the current location


### PR DESCRIPTION
**Issue Number 514**

The closest issue I could find is https://github.com/namespace-ee/react-calendar-timeline/issues/514
moveResizeValidator for dragging should be able to return time and groupDelta to block drag to specific group.

**Overview of PR**

Two more arguments added to moveResizeValidator:
 - dragOrderIndex (original group index of item)
 - dragGroupDelta (group shift difference on dragging)

Now moveResizeValidator can return either:
 - timestamp in ms (integer) _as before_
 - object with `dragTime` timestamp in ms (integer) and `dragGroupDelta` final group index shift (integer) _new_

Added [small demo](https://github.com/namespace-ee/react-calendar-timeline/pull/787/files#diff-dd31c573e1ac62912d65047e919bfd0df63491c87aaee6550d04612c26bc1874R145-R151) with even/odd movement validation (item from even row can be moved to only even row and vice versa)