### PR TITLE
Fix controlled scroll moves onScroll event

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -33,6 +33,14 @@ import TimelineHeaders from './headers/TimelineHeaders'
 import DateHeader from './headers/DateHeader'
 import SidebarHeader from './headers/SidebarHeader'
 
+function defaultOnTimeChange(
+  visibleTimeStart,
+  visibleTimeEnd,
+  updateScrollCanvas
+) {
+  updateScrollCanvas(visibleTimeStart, visibleTimeEnd)
+}
+
 export default class ReactCalendarTimeline extends Component {
   static propTypes = {
     groups: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
@@ -219,13 +227,7 @@ export default class ReactCalendarTimeline extends Component {
     // which needs to update the props visibleTimeStart and visibleTimeEnd to the ones passed
     visibleTimeStart: null,
     visibleTimeEnd: null,
-    onTimeChange: function(
-      visibleTimeStart,
-      visibleTimeEnd,
-      updateScrollCanvas
-    ) {
-      updateScrollCanvas(visibleTimeStart, visibleTimeEnd)
-    },
+    onTimeChange: defaultOnTimeChange,
     // called when the canvas area of the calendar changes
     onBoundsChange: null,
     children: null,
@@ -275,6 +277,7 @@ export default class ReactCalendarTimeline extends Component {
 
     let visibleTimeStart = null
     let visibleTimeEnd = null
+    let shouldNotCallOnScroll = false
 
     if (this.props.defaultTimeStart && this.props.defaultTimeEnd) {
       visibleTimeStart = this.props.defaultTimeStart.valueOf()
@@ -282,6 +285,7 @@ export default class ReactCalendarTimeline extends Component {
     } else if (this.props.visibleTimeStart && this.props.visibleTimeEnd) {
       visibleTimeStart = this.props.visibleTimeStart
       visibleTimeEnd = this.props.visibleTimeEnd
+      shouldNotCallOnScroll = this.props.onTimeChange === defaultOnTimeChange ? true : false
     } else {
       //throwing an error because neither default or visible time props provided
       throw new Error(
@@ -298,6 +302,7 @@ export default class ReactCalendarTimeline extends Component {
       width: 1000,
       visibleTimeStart: visibleTimeStart,
       visibleTimeEnd: visibleTimeEnd,
+      shouldNotCallOnScroll,
       canvasTimeStart: canvasTimeStart,
       canvasTimeEnd: canvasTimeEnd,
       selectedItem: null,
@@ -1056,6 +1061,7 @@ export default class ReactCalendarTimeline extends Component {
                   traditionalZoom={traditionalZoom}
                   onScroll={this.onScroll}
                   isInteractingWithItem={isInteractingWithItem}
+                  shouldNotCallOnScroll={this.state.shouldNotCallOnScroll}
                 >
                   <MarkerCanvas>
                     {this.columns(

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -12,7 +12,8 @@ class ScrollElement extends Component {
     isInteractingWithItem: PropTypes.bool.isRequired,
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
-    onScroll: PropTypes.func.isRequired
+    onScroll: PropTypes.func.isRequired,
+    shouldNotCallOnScroll: PropTypes.bool.isRequired,
   }
 
   constructor() {
@@ -22,14 +23,6 @@ class ScrollElement extends Component {
     }
   }
 
-  /**
-   * needed to handle scrolling with trackpad
-   */
-  handleScroll = () => {
-    const scrollX = this.scrollComponent.scrollLeft
-    this.props.onScroll(scrollX)
-  }
-
   refHandler = el => {
     this.scrollComponent = el
     this.props.scrollRef(el)
@@ -37,12 +30,13 @@ class ScrollElement extends Component {
       el.addEventListener('wheel', this.handleWheel, {passive: false});
     }
   }
-  
 
   handleWheel = e => {
-    const { traditionalZoom } = this.props
+    if (this.props.shouldNotCallOnScroll) {
+      e.preventDefault()
+    }
 
-    
+    this.props.onScroll(this.scrollComponent.scrollLeft)
 
     // zoom in the time dimension
     if (e.ctrlKey || e.metaKey || e.altKey) {


### PR DESCRIPTION
* Addressed Issue: [805](https://github.com/namespace-ee/react-calendar-timeline/issues/805)
* Overview:
1. Removes unnecessary `onScroll` event in `Timeline.js`.
2. Handles scroll moving in controlled mode.