### PR TITLE
Fix/showing selected items without canvas verify

### DIFF
--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -93,7 +93,13 @@ export default class Items extends Component {
   getVisibleItems(canvasTimeStart, canvasTimeEnd) {
     const { keys, items } = this.props
 
-    return getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys)
+    return getVisibleItems(
+        items,
+        canvasTimeStart,
+        canvasTimeEnd,
+        keys,
+        item => this.isSelected(item, keys.itemIdKey)
+      )
   }
 
   render() {

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -277,9 +277,11 @@ export function getGroupedItems(items, groupOrders) {
 export function getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys, isSelectedItem) {
   const { itemTimeStartKey, itemTimeEndKey } = keys
 
+  const hasFunctionToVerify = !!isSelectedItem
+
   return items.filter(item => {
     return (
-      isSelectedItem(item) || 
+      hasFunctionToVerify && isSelectedItem(item) || 
       (
         _get(item, itemTimeStartKey) <= canvasTimeEnd &&
         _get(item, itemTimeEndKey) >= canvasTimeStart

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -274,13 +274,16 @@ export function getGroupedItems(items, groupOrders) {
   return groupedItems
 }
 
-export function getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys) {
+export function getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys, isSelectedItem) {
   const { itemTimeStartKey, itemTimeEndKey } = keys
 
   return items.filter(item => {
     return (
-      _get(item, itemTimeStartKey) <= canvasTimeEnd &&
-      _get(item, itemTimeEndKey) >= canvasTimeStart
+      isSelectedItem(item) || 
+      (
+        _get(item, itemTimeStartKey) <= canvasTimeEnd &&
+        _get(item, itemTimeEndKey) >= canvasTimeStart
+      )
     )
   })
 }


### PR DESCRIPTION
**Reason of PR**

This PR comes to solution the bug that pops up when you have a button to modify visibleTimeStart and visibleTimeEnd while has a item in drag.

actualy exists a function to provide only that visible items and that function is based on the start_time and end_time of item, but when you are dragging the item and modifying the visibleStartTime and visibleEndTime, the item hasn't the values modifieds, then the calendar don't show it.

Is possible to solution this problem modifying the values when you are dragging the item, but I believe when you are dragging the item the values shouldn't be modify the values and only should modify when drop it and the modify of items state at each event of drag i believe is bad to performance

**Overview of PR**

I only passed a function that already exists via props to the another function that does the verification that I commented above

I don't tested because I can't time to does that, sorry, but I believe is all right
_Don't forget to update the CHANGELOG.md file with any changes that are in this PR_
