### PR TITLE
fixed timeline onScroll handler min and max value

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -497,20 +497,32 @@ export default class ReactCalendarTimeline extends Component {
 
   onScroll = scrollX => {
     const width = this.state.width
-
-    const canvasTimeStart = this.state.canvasTimeStart
-
     const zoom = this.state.visibleTimeEnd - this.state.visibleTimeStart
+    const canvasTimeStart = this.state.canvasTimeStart
+    const newVsibleTimeStart = canvasTimeStart + zoom * scrollX / width
+    
+    let newScrollX = scrollX
 
-    const visibleTimeStart = canvasTimeStart + zoom * scrollX / width
+    // prevent scroll to the value less then visibleTimeStart and more then visibleTimeEnd including zoom value
+
+    if (this.props.visibleTimeStart && this.props.visibleTimeEnd) {
+      if (newVsibleTimeStart < this.props.visibleTimeStart) {
+        newScrollX = this.scrollHeaderRef.scrollLeft
+      } else if (newVsibleTimeStart + zoom > this.props.visibleTimeEnd) {
+        newScrollX = this.scrollHeaderRef.scrollLeft
+      }
+      
+      this.scrollHeaderRef.scrollLeft = newScrollX
+      this.scrollComponent.scrollLeft = newScrollX
+    } 
 
     if (
-      this.state.visibleTimeStart !== visibleTimeStart ||
-      this.state.visibleTimeEnd !== visibleTimeStart + zoom
+      this.state.visibleTimeStart !== newVsibleTimeStart ||
+      this.state.visibleTimeEnd !== newVsibleTimeStart + zoom
     ) {
       this.props.onTimeChange(
-        visibleTimeStart,
-        visibleTimeStart + zoom,
+        newVsibleTimeStart,
+        newVsibleTimeStart + zoom,
         this.updateScrollCanvas
       )
     }


### PR DESCRIPTION

addressed Issue: [805](https://github.com/namespace-ee/react-calendar-timeline/issues/805), and probably more.

**Overview of PR**

fixed scroll of the timeline to prevent scrolling behind visibleTimeStart and visibleTimeEnd min and max values