### PR TITLE
:bug: fix horizontal scroll issue

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -461,8 +461,8 @@ export default class ReactCalendarTimeline extends Component {
         (prevState.visibleTimeStart - prevState.canvasTimeStart) /
         oldZoom
     )
+    this.scrollComponent.scrollLeft = scrollLeft
     if (componentScrollLeft !== scrollLeft) {
-      this.scrollComponent.scrollLeft = scrollLeft
       this.scrollHeaderRef.scrollLeft = scrollLeft
     }
   }


### PR DESCRIPTION
- related to horizontal scroll issue #805, which says visibleTimeStart, End works to only header. Actually the same is true of onTimeChange.
- This must solve second codesandbox example of #805.