### PR TITLE
Add order enforcement in stack process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 * Add unit argument to onZoom and onTimeChange callbacks
 * Add `className` prop to Timeline component to override `react-calendar-timeline` class #682
 * Fix injecting custom vertical line's class names for time periods longer than day
+* Add shouldStackEnforceOrder parameter for groups to keep the consistent order of items
 
 ## 0.26.7
 


### PR DESCRIPTION
includes creation of group parameter
shouldStackEnforceOrder

**Issue Number**

In some cases, it is important to enforce the order of items in the same group because they are not of the same type.
In the images below, I have added a few items which are meant to be stacked, but the first two red items are related to the first blue item, the next two red items to the next blue item, and the last red item to the last blue item.

With the current code, what we get does not enforce this order (and there is no way to enforce it)
![image](https://user-images.githubusercontent.com/1941948/154737502-0e046821-3cb2-4251-8526-3a2aa6b3e9e0.png)

This PR makes sure that an item cannot be above an item which is in horizontal collision.
The resulting screenshot is the following:
![image](https://user-images.githubusercontent.com/1941948/154737548-c18ea076-8bc0-49b2-92ef-632347797600.png)


**Overview of PR**

This PR creates a new group parameter "shouldStackEnforceOrder". 
Clearly, this parameter depends upon isStacked. If isStacked is undefined or false, this new parameter has no effect.
If shouldStackEnforceOrder is defined and true for a group, it uses a slightly modified collision method which ensures order is enforced, as shown on the screenshots above.
