### PR TITLE
fix: fixing bug that does not allow group.height property to function

### DIFF
--- a/__tests__/utils/calendar/__snapshots__/get-ordered-groups-with-items.js.snap
+++ b/__tests__/utils/calendar/__snapshots__/get-ordered-groups-with-items.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getGroupWithItemDimensions should work as expected 1`] = `
+exports[`getOrderedGroupsWithItems should work as expected 1`] = `
 Object {
   "1": Object {
     "group": Object {

--- a/__tests__/utils/calendar/get-group-with-item-dimensions.js
+++ b/__tests__/utils/calendar/get-group-with-item-dimensions.js
@@ -52,5 +52,23 @@ describe('getGroupWithItemDimensions', ()=>{
             props.stackItems
         )).not.toBe(groupWithItems)
     })
+    it('should allow for the group.height property to override the manual calculation', () => {
+        const testHeight = 567.6
+        const groupWithItemsAndSetHeight ={
+            group: {id: '1', height: testHeight},
+            items
+        }
+        const result = getGroupWithItemDimensions(
+            groupWithItemsAndSetHeight,
+            props.keys,
+            state.canvasTimeStart,
+            state.canvasTimeEnd,
+            state.width*3,
+            props.lineHeight,
+            props.itemHeightRatio,
+            props.stackItems
+        )
+        expect(result.height).toEqual(testHeight)
+    })
 })
 

--- a/__tests__/utils/calendar/get-ordered-groups-with-items.js
+++ b/__tests__/utils/calendar/get-ordered-groups-with-items.js
@@ -3,7 +3,7 @@ import {items, groups} from '../../../__fixtures__/itemsAndGroups'
 import {props} from '../../../__fixtures__/stateAndProps'
 
 
-describe('getGroupWithItemDimensions', ()=>{
+describe('getOrderedGroupsWithItems', ()=>{
     it('should work as expected', ()=>{
         expect(getOrderedGroupsWithItems(groups, items, props.keys)).toMatchSnapshot()
     })

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -689,7 +689,13 @@ export function getGroupWithItemDimensions(
       itemHeightRatio
     })
   })
-  const { groupHeight } = stackGroup(itemDimensions, stackItems, lineHeight)
+  //If group height property is specified, use that instead of manual calculation
+  let groupHeightProp = null;
+  if (groupWithItems && groupWithItems.group) groupHeightProp = groupWithItems.group.height
+  const { groupHeight } = groupHeightProp ? 
+    { groupHeight: groupHeightProp } : 
+    stackGroup(itemDimensions, stackItems, lineHeight)
+
   return {
     ...groupWithItems,
     itemDimensions: itemDimensions,


### PR DESCRIPTION
## Issue Number

Currently the group.height property is stated in the docs as being able to be set and override the calculated group height. However, this capability is currently not implemented. This PR implements that capability.

## Overview of PR

- tests/utils/calendar/get-ordered-groups-with-items.js
    - This test file had the wrong name in the describe block. Fixed that.
- tests/utils/calendar/snapshots/get-ordered-groups-with-items.js.snap
    - Snapshot test modified due to name change in describe block above
- tests/utils/calendar/get-group-with-item-dimensions.js
    - Added test to cover new functionality
- src/lib/utility/calendar.js
    - Implemented capability. If the group height is not undefined, use it. If it is undefined, calculate.
    
Don't forget to update the CHANGELOG.md file with any changes that are in this PR