### PR TITLE
fix: On time change called (no before) on item drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,6 +607,9 @@ Plenty of bugfixes, tests and new demos in these 0.14 patch releases.
 * Fix demo for IE11 #44 by @lucidlemon
 * Package a .css file, not a .scss file as previously done. @mariusandra
 
+### fix
+* fix the isInteractingWithItem variable
+
 [0.9.0]: https://github.com/namespace-ee/react-calendar-timeline/compare/v0.8.6...v0.9.0
 [0.10.0]: https://github.com/namespace-ee/react-calendar-timeline/compare/v0.9.0...v0.10.0
 [0.10.1]: https://github.com/namespace-ee/react-calendar-timeline/compare/v0.10.0...v0.10.1

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -966,7 +966,8 @@ export default class ReactCalendarTimeline extends Component {
       visibleTimeStart,
       visibleTimeEnd,
       canvasTimeStart,
-      canvasTimeEnd
+      canvasTimeEnd,
+      selectedItem
     } = this.state
     let { dimensionItems, height, groupHeights, groupTops } = this.state
 
@@ -974,7 +975,7 @@ export default class ReactCalendarTimeline extends Component {
     const canvasWidth = getCanvasWidth(width, buffer)
     const minUnit = getMinUnit(zoom, width, timeSteps)
 
-    const isInteractingWithItem = !!draggingItem || !!resizingItem
+    const isInteractingWithItem = !!draggingItem || !!resizingItem || !!selectedItem 
 
     if (isInteractingWithItem) {
       const stackResults = stackTimelineItems(


### PR DESCRIPTION
#838

[Link issue.](https://github.com/namespace-ee/react-calendar-timeline/issues/838)

I think that is a misunderstanding with the bug, why it should have been called onTimeChange when I drag i item?

docs:

## onTimeChange(visibleTimeStart, visibleTimeEnd, updateScrollCanvas, unit)
A function that's called when the user tries to **scroll**. Call the passed `updateScrollCanvas(start, end)` with the updated visibleTimeStart and visibleTimeEnd (as unix timestamps in milliseconds) to change the scroll behavior, for example to limit scrolling.