### PR TITLE
build: externalize react/jsx-runtime and react-dom/client

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
       fileName: (format) => `react-calendar-timeline.${format}.js`
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
       output: {
         globals: {
           react: 'React'


### PR DESCRIPTION
**Issue Number**

Fixes #937 

Would be awesome for having a quick merge, because no breaking change, no problem, just removes overhead, reduce bundle size, and also provides a fix.

**Overview of PR**

Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production, by externalizing react/jsx-runtime and also for the future react-dom/client

_Don't forget to update the CHANGELOG.md file with any changes that are in this PR_
