### PR TITLE
Issue 946: reassign adjusted value to time

### DIFF
--- a/src/lib/utility/calendar.tsx
+++ b/src/lib/utility/calendar.tsx
@@ -79,7 +79,7 @@ export function iterateTimes(
 
   if (timeSteps[unit] && timeSteps[unit] > 1) {
     const value = time.get(unit)
-    time.set(unit, value - (value % timeSteps[unit]))
+    time = time.set(unit, value - (value % timeSteps[unit]))
   }
 
   while (time.valueOf() < end) {


### PR DESCRIPTION
Fixes #946

https://github.com/namespace-ee/react-calendar-timeline/issues/946

**Overview of PR**

Rather than updating the dayjs object, dayjs.set() returns a copy of it. This ensures the time variable is update to use the offset.
