### PR TITLE
Update package.json to use .cjs extension #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "main": "./dist/react-calendar-timeline.umd.js",
+  "main": "./dist/react-calendar-timeline.cjs.js",
   "module": "./dist/react-calendar-timeline.es.js",
   "sideEffects": false,
   "exports": {
@@ -25,7 +25,7 @@
       "sass": "./dist/Timeline.scss",
       "style": "./dist/Timeline.css",
       "import": "./dist/react-calendar-timeline.es.js",
-      "require": "./dist/react-calendar-timeline.umd.js"
+      "require": "./dist/react-calendar-timeline.cjs.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The current mappings are incorrect and point to two `.umd.js` files that are actually being build out as `.cjs.js` files.

**Issue Number**

Link to issue this PR addresses.  If no issue exists, please provide reasoning for PR.

**Overview of PR**

The `main` and `exports.require` are incorrect and pointing to `.umd.js` files that are actually being build out as `.cjs.js` files.

* The [current package.json](https://www.npmjs.com/package/react-calendar-timeline?activeTab=code) references two `.umd.js` extensions
* Actual dist files are `.cjs` extensions, there are no `.umd` files built

_Don't forget to update the CHANGELOG.md file with any changes that are in this PR_

![package](https://github.com/user-attachments/assets/63d83ceb-44ef-451e-b2ba-771fe04bae52)
![dist](https://github.com/user-attachments/assets/1e3da5c9-5a59-4a4f-8f19-15f6d4149071)

