### PR TITLE
fix: Externalize dayjs dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 * Fix issue where the redraw mechanism was not based on the `buffer` prop.
 * Fix incorrect references to ".umd.js" file paths in the package.json
+* Externalize dayjs dependency. That allows using dayjs locale, but needs consuming application to install dayjs.
 
 ## 0.30.0 (beta)
 Huge update made by @Remco4EF and @remcoblumink

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "memoize-one": "^6.0.0"
   },
   "peerDependencies": {
-    "dayjs": ">=1.10.0",
+    "dayjs": "^1.11.10",
     "interactjs": "1.10.27",
     "react": "^18 || ^19.0.0-rc-66855b96-20241106",
     "react-dom": "^18 || ^19.0.0-rc-66855b96-20241106"
@@ -108,7 +108,6 @@
     "@typescript-eslint/parser": "^8.8.1",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "cross-env": "^7.0.3",
-    "dayjs": "^1.11.10",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^28.8.3",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
       fileName: (format) => `react-calendar-timeline.${format}.js`
     },
     rollupOptions: {
-      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client', 'dayjs'],
       output: {
         globals: {
           react: 'React'


### PR DESCRIPTION
Add dayjs dependency in `external` rollup configuration option. As it is a peer dependency it shouldn't be included in the bundle.
Consuming applications have to add dayjs as a dependency. This also allows changing locale in consuming applications.

**Issue Number**

Fixes #964. This allows using a dayjs locale other than English in consuming applications so the dates in the Timeline header (months, days of week) use this locale.

**Overview of PR**

Add the dayjs in rollup's `external` configuration option.

Remove dayjs devDependency and use its version in the peerDependency.
The devDependency is not needed [As of npm v7, peerDependencies are installed by default.(https://docs.npmjs.com/cli/v11/configuring-npm/package-json#:~:text=As%20of%20npm%20v7%2C%20peerDependencies%20are%20installed%20by%20default.). npm v7 and higher is included in node>=15