### PR TITLE
[#977] feat: Add support for dynamic item sizing and vertical gap in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 * Fix issue where the redraw mechanism was not based on the `buffer` prop.
 * Fix incorrect references to ".umd.js" file paths in the package.json
+* Added support for dynamic item sizing with an optional per-item `height` override prop.
+* Introduced `itemVerticalGap` timeline prop to ensure consistent spacing between timeline items, which takes precedence over the `itemHeightRatio` setting when specified.
 
 ## 0.30.0 (beta)
 Huge update made by @Remco4EF and @remcoblumink

--- a/src/lib/Timeline.tsx
+++ b/src/lib/Timeline.tsx
@@ -85,6 +85,12 @@ export type ReactCalendarTimelineProps<
   minResizeWidth?: number | undefined
   lineHeight: number
   itemHeightRatio: number
+  /**
+   * vertical gap (in pixels) added above and below each item.
+   * Applies globally for consistent spacing between items.
+   * If it's defined it will override `lineHeight`.
+   */
+  itemVerticalGap?: number | undefined
   minZoom: number
   maxZoom: number
   clickTolerance?: number | undefined
@@ -325,6 +331,7 @@ export default class ReactCalendarTimeline<
       state.resizingEdge!,
       state.resizeTime!,
       state.newGroupOrder!,
+      props.itemVerticalGap
     )
 
     state.dimensionItems = dimensionItems
@@ -392,6 +399,7 @@ export default class ReactCalendarTimeline<
           prevState.resizingEdge,
           prevState.resizeTime,
           prevState.newGroupOrder,
+          nextProps.itemVerticalGap,
         ),
       )
     }
@@ -451,6 +459,7 @@ export default class ReactCalendarTimeline<
       this.state.resizingEdge,
       this.state.resizeTime,
       this.state.newGroupOrder,
+      props.itemVerticalGap,
     )
 
     // this is needed by dragItem since it uses pageY from the drag events
@@ -1017,6 +1026,7 @@ export default class ReactCalendarTimeline<
         this.state.resizingEdge,
         this.state.resizeTime,
         this.state.newGroupOrder,
+        this.props.itemVerticalGap,
       )
       dimensionItems = stackResults.dimensionItems
       height = stackResults.height

--- a/src/lib/types/main.ts
+++ b/src/lib/types/main.ts
@@ -38,6 +38,11 @@ export interface TimelineItemBase<DateType> {
   itemProps?: HTMLProps<HTMLDivElement>
   isOverlay?: boolean | undefined
   dimensions?: Dimension | undefined
+  /**
+   * Fixed pixel height for this item.
+   * Overrides `lineHeight` for this item only.
+   */
+  height?: number | undefined
 }
 
 export interface TimelineContext {


### PR DESCRIPTION
### Summary
Fixes #977
Adds support for dynamic item sizing and improves vertical gap control in the timeline component.

### Overview
#### Dynamic item height
This pull request introduces dynamic item height support in the timeline component. Each item can define its height, controlled at the item level through a new optional `height` prop.
The layout calculations, including group height, item positioning, and collision detection, have been updated to account for these per-item height values.

#### Consistent vertical gap
Additionally, `itemVerticalGap` timeline prop has been added to maintain consistent vertical spacing between items of varying heights, replacing the previous `itemHeightRatio` based gap logic for dynamic scenarios.
