### PR TITLE
Add automated npm release via GitHub Actions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,3 +21,38 @@ Before you submit your pull request please read and consider the following guide
 All code is linted for consistency.
 
 * To check for style lint run `npm run lint`. To fix linting errors, run `npm run lint:fix`
+
+## Releasing
+
+Releases are automated via GitHub Actions. When a version tag is pushed, the workflow runs lint, tests, and build, then publishes to npm.
+
+### Steps
+
+1. Bump the version in `package.json`
+2. Commit the version bump
+3. Create a git tag matching the version (prefixed with `v`)
+4. Push the commit and tag
+
+### Stable release
+
+```bash
+# Update version in package.json to 0.31.0
+git add package.json
+git commit -m "Bump version to 0.31.0"
+git tag v0.31.0
+git push origin main --tags
+```
+
+### Prerelease (beta, alpha, rc)
+
+Prerelease tags publish under their respective npm dist-tag (e.g., `beta`) so they don't become the default install.
+
+```bash
+# Update version in package.json to 0.31.0-beta.1
+git add package.json
+git commit -m "Bump version to 0.31.0-beta.1"
+git tag v0.31.0-beta.1
+git push origin main --tags
+```
+
+**Note:** The tag version must match the version in `package.json` or the workflow will fail.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Validate tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Determine npm dist-tag
+        id: dist-tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" == *"-beta"* ]]; then
+            echo "tag=beta" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-alpha"* ]]; then
+            echo "tag=alpha" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-rc"* ]]; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        run: npm publish --tag ${{ steps.dist-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 ## Unreleased
 
 * Fix `vite.config.mts` reference in `tsconfig.node.json`.
+* Add automated npm release via GitHub Actions on git tag push (`v*`), with support for beta/alpha/rc dist-tags.
 
 ## 0.30.0 (beta.4)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.30.0-beta.5",
+  "version": "0.30.0-beta.6",
   "description": "react-calendar-timeline",
   "packageManager": "npm@10.1.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Publishes to npm on tag push (v*) with lint, test, and build checks. Prerelease tags (-beta, -alpha, -rc) publish under their respective npm dist-tag instead of latest.

## Issue Number

No existing issue — this adds CI/CD infrastructure for automated npm publishing, which the project currently lacks.

## Overview of PR

Adds a GitHub Actions workflow that automatically publishes to npm when a version tag (`v*`) is pushed. The workflow:

- Runs lint, tests, and build before publishing — aborting the release if any step fails
- Validates that the git tag version matches `package.json` to prevent mismatched releases
- Publishes prerelease tags (`-beta`, `-alpha`, `-rc`) under their respective npm dist-tag instead of `latest`, so they don't become the default install

Also updates CONTRIBUTING.md with step-by-step release instructions and bumps the version to `0.30.0-beta.6`.

**Requires** adding an `NPM_TOKEN` repository secret in GitHub Settings before the first release.

_CHANGELOG.md has been updated._
