### PR TITLE
Add npm upgrade step for OIDC auth support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Update npm to latest (>= 11.5 required for OIDC auth)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 * Fix `vite.config.mts` reference in `tsconfig.node.json`.
 * Add automated npm release via GitHub Actions on git tag push (`v*`), with support for beta/alpha/rc dist-tags.
 * Add CI workflow for linting and building on Node.js 22 (tests skipped until migrated to TypeScript).
+* Switch npm release workflow to OIDC Trusted Publishing with provenance attestation (no `NPM_TOKEN` required).
 
 ## 0.30.0 (beta.4)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar-timeline",
-  "version": "0.30.0-beta.9",
+  "version": "0.30.0-beta.12",
   "description": "react-calendar-timeline",
   "packageManager": "npm@10.1.0",
   "scripts": {


### PR DESCRIPTION
**Issue Number**

No linked issue. This PR improves the CI/CD pipeline security by adopting npm's OIDC Trusted Publishing, eliminating the need for long-lived npm access tokens.

**Overview of PR**

- Switch the release workflow from `NPM_TOKEN` secret to OIDC-based Trusted Publishing with provenance attestation (`--provenance`), removing the need for stored npm credentials.
- Add `id-token: write` permission and `npm install -g npm@latest` step (npm >= 11.5 required for OIDC auth).
- Upgrade Node.js to 22 in the release workflow and 24 in the CI workflow.
- Bump version to `0.30.0-beta.12`.