### PR TITLE
Add option to continue scroll when leaving scroll ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 
 ## Unreleased
 
+* Add option to continue scrolling when mouse leaves timeline div.
+
 ## 0.30.0 (beta.18)
 
 * Migrate test suite from Jest/Enzyme to Vitest + React Testing Library.

--- a/src/lib/Timeline.tsx
+++ b/src/lib/Timeline.tsx
@@ -107,6 +107,10 @@ export type ReactCalendarTimelineProps<
   itemTouchSendsClick?: boolean | undefined;
   timeSteps: TimelineTimeSteps;
   scrollRef?: (el: HTMLDivElement) => void;
+  /**
+   * Continue dragging items when the mouse leaves the scrollRef element.
+   */
+  continueDragOnMouseLeave?: boolean | undefined;
   onItemDrag?(itemDragObject: OnItemDragObjectMove | OnItemDragObjectResize): void;
   onItemMove?(itemId: Id, dragTime: number, newGroupOrder: number): void;
   onItemResize?(itemId: Id, endTimeOrStartTime: number, edge: ResizeEdge): void;
@@ -1054,6 +1058,7 @@ export default class ReactCalendarTimeline<
                   traditionalZoom={!!traditionalZoom}
                   onScroll={this.onScroll}
                   scrollOffset={scrollOffset}
+                  continueDragOnMouseLeave={this.props.continueDragOnMouseLeave}
                 >
                   <MarkerCanvas>
                     {this.columns(canvasTimeStart, canvasTimeEnd, canvasWidth, minUnit, timeSteps, height)}

--- a/src/lib/scroll/ScrollElement.tsx
+++ b/src/lib/scroll/ScrollElement.tsx
@@ -11,6 +11,7 @@ type Props = {
   onWheelZoom: (speed: number, xPosition: number, deltaY: number) => void;
   onScroll: (n: number) => void;
   scrollOffset: number;
+  continueDragOnMouseLeave?: boolean;
 };
 
 type State = {
@@ -68,6 +69,9 @@ class ScrollElement extends Component<Props, State> {
       this.handleTouchStart(e);
     } else if (e.pointerType === "mouse") {
       this.handleMouseDown(e);
+      if (this.props.continueDragOnMouseLeave) {
+        this.scrollComponentRef.current?.setPointerCapture(e.pointerId);
+      }
     }
   };
 
@@ -169,7 +173,7 @@ class ScrollElement extends Component<Props, State> {
   };
 
   handlePointerLeave = (e: PointerEvent) => {
-    if (e.pointerType === "mouse") {
+    if (e.pointerType === "mouse" && !this.props.continueDragOnMouseLeave) {
       this.dragLastPosition = null;
       this.setState({
         isDragging: false,

--- a/src/lib/scroll/ScrollElement.tsx
+++ b/src/lib/scroll/ScrollElement.tsx
@@ -69,9 +69,6 @@ class ScrollElement extends Component<Props, State> {
       this.handleTouchStart(e);
     } else if (e.pointerType === "mouse") {
       this.handleMouseDown(e);
-      if (this.props.continueDragOnMouseLeave) {
-        this.scrollComponentRef.current?.setPointerCapture(e.pointerId);
-      }
     }
   };
 
@@ -80,6 +77,9 @@ class ScrollElement extends Component<Props, State> {
       this.handleTouchMove(e);
     } else if (e.pointerType === "mouse") {
       this.handleMouseMove(e);
+    }
+    if (this.props.continueDragOnMouseLeave) {
+      this.scrollComponentRef.current?.setPointerCapture(e.pointerId);
     }
   };
 


### PR DESCRIPTION
**Issue Number**

Currently when scrolling through dragging with the mouse and you leave the timeline div it stops scrolling. When the timeline is a small part of the page with only very few groups that are not very high this is very annoying.

**Overview of PR**

The PR adds a prop option (`continueDragOnMouseLeave`) to the main timeline object that makes the `ScrollElement` capture the pointer event if it is set to true. This allows us to follow the mouse movement outside of the timeline DOM which gives smoother and more predictable scrolling behaviour. By default this option is disables, which means behaviour is by default the same as before.